### PR TITLE
feat(sorosave): dispute voting with configurable quorum

### DIFF
--- a/contracts/sorosave/src/admin.rs
+++ b/contracts/sorosave/src/admin.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{Address, Env, String};
 
 use crate::errors::ContractError;
 use crate::storage;
-use crate::types::{Dispute, GroupStatus};
+use crate::types::{Dispute, DisputeVotes, GroupStatus};
 
 pub fn pause_group(env: &Env, admin: Address, group_id: u64) -> Result<(), ContractError> {
     admin.require_auth();
@@ -83,6 +83,15 @@ pub fn raise_dispute(
     group.status = GroupStatus::Disputed;
     storage::set_group(env, &group);
     storage::set_dispute(env, group_id, &dispute);
+    storage::set_dispute_votes(
+        env,
+        group_id,
+        &DisputeVotes {
+            approvals: 0,
+            rejections: 0,
+            total_members: group.members.len(),
+        },
+    );
 
     env.events()
         .publish((crate::symbol_short!("dispute"),), (group_id, member));
@@ -106,9 +115,109 @@ pub fn resolve_dispute(env: &Env, admin: Address, group_id: u64) -> Result<(), C
     group.status = GroupStatus::Active;
     storage::set_group(env, &group);
     storage::remove_dispute(env, group_id);
+    storage::remove_dispute_votes(env, group_id);
+    for m in group.members.iter() {
+        storage::remove_dispute_vote(env, group_id, &m);
+    }
 
     env.events()
         .publish((crate::symbol_short!("resolved"),), group_id);
+
+    Ok(())
+}
+
+pub fn set_dispute_quorum(
+    env: &Env,
+    admin: Address,
+    group_id: u64,
+    quorum_bps: u32,
+) -> Result<(), ContractError> {
+    admin.require_auth();
+
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if admin != group.admin && admin != storage::get_admin(env) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    // Must be within (0%, 100%]
+    if quorum_bps == 0 || quorum_bps > 10_000 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    storage::set_dispute_quorum_bps(env, group_id, quorum_bps);
+    Ok(())
+}
+
+pub fn vote_on_dispute(
+    env: &Env,
+    member: Address,
+    group_id: u64,
+    approve: bool,
+) -> Result<(), ContractError> {
+    member.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if group.status != GroupStatus::Disputed {
+        return Err(ContractError::GroupNotActive);
+    }
+
+    // membership check
+    let mut is_member = false;
+    for m in group.members.iter() {
+        if m == member {
+            is_member = true;
+            break;
+        }
+    }
+    if !is_member {
+        return Err(ContractError::NotMember);
+    }
+
+    if storage::has_dispute_vote(env, group_id, &member) {
+        return Err(ContractError::AlreadyContributed);
+    }
+
+    let mut votes = storage::get_dispute_votes(env, group_id).unwrap_or(DisputeVotes {
+        approvals: 0,
+        rejections: 0,
+        total_members: group.members.len(),
+    });
+
+    if approve {
+        votes.approvals += 1;
+    } else {
+        votes.rejections += 1;
+    }
+
+    storage::set_dispute_vote(env, group_id, &member, approve);
+    storage::set_dispute_votes(env, group_id, &votes);
+
+    let quorum_bps = storage::get_dispute_quorum_bps(env, group_id) as u64;
+    let approvals_bps = (votes.approvals as u64 * 10_000) / votes.total_members as u64;
+    let rejections_bps = (votes.rejections as u64 * 10_000) / votes.total_members as u64;
+
+    if approvals_bps >= quorum_bps {
+        group.status = GroupStatus::Active;
+        storage::set_group(env, &group);
+        storage::remove_dispute(env, group_id);
+        storage::remove_dispute_votes(env, group_id);
+        for m in group.members.iter() {
+            storage::remove_dispute_vote(env, group_id, &m);
+        }
+        env.events()
+            .publish((crate::symbol_short!("dsp_appv"),), group_id);
+    } else if rejections_bps >= quorum_bps {
+        // rejected dispute keeps group active as well
+        group.status = GroupStatus::Active;
+        storage::set_group(env, &group);
+        storage::remove_dispute(env, group_id);
+        storage::remove_dispute_votes(env, group_id);
+        for m in group.members.iter() {
+            storage::remove_dispute_vote(env, group_id, &m);
+        }
+        env.events()
+            .publish((crate::symbol_short!("dsp_rejt"),), group_id);
+    }
 
     Ok(())
 }

--- a/contracts/sorosave/src/admin.rs
+++ b/contracts/sorosave/src/admin.rs
@@ -193,8 +193,11 @@ pub fn vote_on_dispute(
     storage::set_dispute_votes(env, group_id, &votes);
 
     let quorum_bps = storage::get_dispute_quorum_bps(env, group_id) as u64;
-    let approvals_bps = (votes.approvals as u64 * 10_000) / votes.total_members as u64;
-    let rejections_bps = (votes.rejections as u64 * 10_000) / votes.total_members as u64;
+    let total_members = votes.total_members as u64;
+
+    // Use ceil division so thresholds like 6667 bps can represent 2/3 membership.
+    let approvals_bps = (votes.approvals as u64 * 10_000 + total_members - 1) / total_members;
+    let rejections_bps = (votes.rejections as u64 * 10_000 + total_members - 1) / total_members;
 
     if approvals_bps >= quorum_bps {
         group.status = GroupStatus::Active;

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -145,6 +145,26 @@ impl SoroSaveContract {
         admin::resolve_dispute(&env, admin, group_id)
     }
 
+    /// Configure dispute quorum in basis points (default 5001 = >50%).
+    pub fn set_dispute_quorum(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        quorum_bps: u32,
+    ) -> Result<(), ContractError> {
+        admin::set_dispute_quorum(&env, admin, group_id, quorum_bps)
+    }
+
+    /// Vote on an active dispute. Auto-resolves once quorum is reached.
+    pub fn vote_on_dispute(
+        env: Env,
+        member: Address,
+        group_id: u64,
+        approve: bool,
+    ) -> Result<(), ContractError> {
+        admin::vote_on_dispute(&env, member, group_id, approve)
+    }
+
     /// Emergency withdraw — distribute remaining funds proportionally to all members.
     pub fn emergency_withdraw(
         env: Env,

--- a/contracts/sorosave/src/storage.rs
+++ b/contracts/sorosave/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::types::{DataKey, Dispute, RoundInfo, SavingsGroup};
+use crate::types::{DataKey, Dispute, DisputeVotes, RoundInfo, SavingsGroup};
 
 const INSTANCE_TTL_THRESHOLD: u32 = 100;
 const INSTANCE_TTL_EXTEND: u32 = 500;
@@ -119,6 +119,54 @@ pub fn set_dispute(env: &Env, group_id: u64, dispute: &Dispute) {
 
 pub fn remove_dispute(env: &Env, group_id: u64) {
     let key = DataKey::Dispute(group_id);
+    env.storage().persistent().remove(&key);
+}
+
+pub fn get_dispute_votes(env: &Env, group_id: u64) -> Option<DisputeVotes> {
+    let key = DataKey::DisputeVotes(group_id);
+    env.storage().persistent().get(&key)
+}
+
+pub fn set_dispute_votes(env: &Env, group_id: u64, votes: &DisputeVotes) {
+    let key = DataKey::DisputeVotes(group_id);
+    env.storage().persistent().set(&key, votes);
+    extend_persistent_ttl(env, &key);
+}
+
+pub fn remove_dispute_votes(env: &Env, group_id: u64) {
+    let key = DataKey::DisputeVotes(group_id);
+    env.storage().persistent().remove(&key);
+}
+
+pub fn has_dispute_vote(env: &Env, group_id: u64, member: &Address) -> bool {
+    let key = DataKey::DisputeVote(group_id, member.clone());
+    env.storage().persistent().has(&key)
+}
+
+pub fn set_dispute_vote(env: &Env, group_id: u64, member: &Address, approve: bool) {
+    let key = DataKey::DisputeVote(group_id, member.clone());
+    env.storage().persistent().set(&key, &approve);
+    extend_persistent_ttl(env, &key);
+}
+
+pub fn remove_dispute_vote(env: &Env, group_id: u64, member: &Address) {
+    let key = DataKey::DisputeVote(group_id, member.clone());
+    env.storage().persistent().remove(&key);
+}
+
+pub fn get_dispute_quorum_bps(env: &Env, group_id: u64) -> u32 {
+    let key = DataKey::DisputeQuorumBps(group_id);
+    env.storage().persistent().get(&key).unwrap_or(5_001)
+}
+
+pub fn set_dispute_quorum_bps(env: &Env, group_id: u64, quorum_bps: u32) {
+    let key = DataKey::DisputeQuorumBps(group_id);
+    env.storage().persistent().set(&key, &quorum_bps);
+    extend_persistent_ttl(env, &key);
+}
+
+pub fn remove_dispute_quorum_bps(env: &Env, group_id: u64) {
+    let key = DataKey::DisputeQuorumBps(group_id);
     env.storage().persistent().remove(&key);
 }
 

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,31 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_dispute_voting_auto_resolve_with_quorum() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.start_group(&admin, &group_id);
+
+    client.raise_dispute(
+        &member1,
+        &group_id,
+        &String::from_str(&env, "Dispute for voting"),
+    );
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Disputed);
+
+    // 3 members total; set quorum to 66.67% (2/3)
+    client.set_dispute_quorum(&admin, &group_id, &6667);
+
+    client.vote_on_dispute(&member1, &group_id, &true);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Disputed);
+
+    client.vote_on_dispute(&member2, &group_id, &true);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Active);
+}

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -51,6 +51,15 @@ pub struct Dispute {
     pub raised_at: u64,
 }
 
+/// Voting state for dispute resolution.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct DisputeVotes {
+    pub approvals: u32,
+    pub rejections: u32,
+    pub total_members: u32,
+}
+
 /// Storage keys for all contract data.
 #[contracttype]
 #[derive(Clone)]
@@ -61,4 +70,7 @@ pub enum DataKey {
     Round(u64, u32),
     MemberGroups(Address),
     Dispute(u64),
+    DisputeVotes(u64),
+    DisputeQuorumBps(u64),
+    DisputeVote(u64, Address),
 }


### PR DESCRIPTION
## Summary
This PR adds on-chain dispute voting and automatic resolution once quorum is reached.

### What changed
- add `vote_on_dispute(member, group_id, approve)`
- add `set_dispute_quorum(admin, group_id, quorum_bps)`
- store per-dispute voting state (`approvals`, `rejections`, `total_members`)
- store per-member vote marker to prevent duplicate voting
- auto-resolve dispute to `Active` when approval or rejection quorum is met
- cleanup vote/dispute storage on resolution
- add test: quorum auto-resolve flow

## Notes
- Default quorum is `5001` bps (>50%).
- Could not run Rust tests in this environment because `cargo` is not installed (`cargo_missing`).

## Files
- `contracts/sorosave/src/admin.rs`
- `contracts/sorosave/src/types.rs`
- `contracts/sorosave/src/storage.rs`
- `contracts/sorosave/src/lib.rs`
- `contracts/sorosave/src/test.rs`
