### PR TITLE
feat(sorosave): support accepted token allowlist in contributions

### DIFF
--- a/contracts/sorosave/src/contribution.rs
+++ b/contracts/sorosave/src/contribution.rs
@@ -4,7 +4,12 @@ use crate::errors::ContractError;
 use crate::storage;
 use crate::types::{GroupStatus, RoundInfo};
 
-pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {
+pub fn contribute(
+    env: &Env,
+    member: Address,
+    group_id: u64,
+    token: Address,
+) -> Result<(), ContractError> {
     member.require_auth();
 
     let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
@@ -37,8 +42,20 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
         return Err(ContractError::AlreadyContributed);
     }
 
+    // Validate token is accepted by this group
+    let mut token_allowed = false;
+    for t in group.accepted_tokens.iter() {
+        if t == token {
+            token_allowed = true;
+            break;
+        }
+    }
+    if !token_allowed {
+        return Err(ContractError::InvalidAmount);
+    }
+
     // Transfer tokens from member to this contract
-    let token_client = soroban_sdk::token::Client::new(env, &group.token);
+    let token_client = soroban_sdk::token::Client::new(env, &token);
     token_client.transfer(
         &member,
         &env.current_contract_address(),
@@ -58,7 +75,7 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
 
     env.events().publish(
         (crate::symbol_short!("contrib"),),
-        (group_id, member, group.contribution_amount),
+        (group_id, member, token, group.contribution_amount),
     );
 
     Ok(())

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -9,6 +9,7 @@ pub fn create_group(
     admin: Address,
     name: String,
     token: Address,
+    accepted_tokens: Vec<Address>,
     contribution_amount: i128,
     cycle_length: u64,
     max_members: u32,
@@ -28,11 +29,17 @@ pub fn create_group(
     let mut members = Vec::new(env);
     members.push_back(admin.clone());
 
+    let mut resolved_tokens = accepted_tokens;
+    if resolved_tokens.is_empty() {
+        resolved_tokens.push_back(token.clone());
+    }
+
     let group = SavingsGroup {
         id: group_id,
         name,
         admin: admin.clone(),
         token,
+        accepted_tokens: resolved_tokens,
         contribution_amount,
         cycle_length,
         max_members,

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -34,6 +34,7 @@ impl SoroSaveContract {
         admin: Address,
         name: String,
         token: Address,
+        accepted_tokens: Vec<Address>,
         contribution_amount: i128,
         cycle_length: u64,
         max_members: u32,
@@ -43,6 +44,7 @@ impl SoroSaveContract {
             admin,
             name,
             token,
+            accepted_tokens,
             contribution_amount,
             cycle_length,
             max_members,
@@ -77,8 +79,13 @@ impl SoroSaveContract {
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.
-    pub fn contribute(env: Env, member: Address, group_id: u64) -> Result<(), ContractError> {
-        contribution::contribute(&env, member, group_id)
+    pub fn contribute(
+        env: Env,
+        member: Address,
+        group_id: u64,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        contribution::contribute(&env, member, group_id, token)
     }
 
     /// Get the status of a specific round.

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec};
 
 use crate::types::GroupStatus;
 use crate::{SoroSaveContract, SoroSaveContractClient};
@@ -28,10 +28,14 @@ fn create_test_group(
     admin: &Address,
     token: &Address,
 ) -> u64 {
+    let mut accepted_tokens = Vec::new(env);
+    accepted_tokens.push_back(token.clone());
+
     client.create_group(
         admin,
         &String::from_str(env, "Test Savings Group"),
         token,
+        &accepted_tokens,
         &1_000_000, // 1 token (7 decimals)
         &86400,     // 1 day cycle
         &5,         // max 5 members
@@ -116,10 +120,14 @@ fn test_full_cycle() {
     token_sac.mint(&member1, &10_000_000);
 
     // Create a new group with the token we control
+    let mut accepted_tokens = Vec::new(&env);
+    accepted_tokens.push_back(token_id.address());
+
     let group_id = client.create_group(
         &admin,
         &String::from_str(&env, "Full Cycle Test"),
         &token_id.address(),
+        &accepted_tokens,
         &1_000_000,
         &86400,
         &5,
@@ -128,8 +136,8 @@ fn test_full_cycle() {
     client.start_group(&admin, &group_id);
 
     // Round 1: both contribute
-    client.contribute(&admin, &group_id);
-    client.contribute(&member1, &group_id);
+    client.contribute(&admin, &group_id, &token_id.address());
+    client.contribute(&member1, &group_id, &token_id.address());
 
     let round = client.get_round_status(&group_id, &1);
     assert!(round.is_complete);
@@ -141,8 +149,8 @@ fn test_full_cycle() {
     let group = client.get_group(&group_id);
     assert_eq!(group.current_round, 2);
 
-    client.contribute(&admin, &group_id);
-    client.contribute(&member1, &group_id);
+    client.contribute(&admin, &group_id, &token_id.address());
+    client.contribute(&member1, &group_id, &token_id.address());
 
     client.distribute_payout(&group_id);
 
@@ -156,10 +164,14 @@ fn test_member_groups() {
     let (env, admin, client, token) = setup_env();
 
     let group1 = create_test_group(&env, &client, &admin, &token);
+    let mut accepted_tokens = Vec::new(&env);
+    accepted_tokens.push_back(token.clone());
+
     let group2 = client.create_group(
         &admin,
         &String::from_str(&env, "Second Group"),
         &token,
+        &accepted_tokens,
         &500_000,
         &43200,
         &3,

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -19,6 +19,7 @@ pub struct SavingsGroup {
     pub name: String,
     pub admin: Address,
     pub token: Address,
+    pub accepted_tokens: Vec<Address>,
     pub contribution_amount: i128,
     pub cycle_length: u64,
     pub max_members: u32,


### PR DESCRIPTION
## Summary
Implements multi-token contribution support via group-level accepted token allowlist.

Closes #4

## What changed
- Added `accepted_tokens: Vec<Address>` to `SavingsGroup` config
- Updated `create_group` to accept `accepted_tokens`
  - If empty, defaults to `[token]` for backwards-safe behavior
- Updated `contribute` signature to `contribute(member, group_id, token)`
- Added token allowlist validation in contribution flow
- Transfers now use the provided contribution token
- Updated tests to use new method signatures

## Validation
- Ran in ephemeral Rust environment (temporary `RUSTUP_HOME/CARGO_HOME`, deleted after run)
- Command: `cargo test --package sorosave`
- Result: ✅ 9 passed / 0 failed

## Files
- `contracts/sorosave/src/types.rs`
- `contracts/sorosave/src/group.rs`
- `contracts/sorosave/src/contribution.rs`
- `contracts/sorosave/src/lib.rs`
- `contracts/sorosave/src/test.rs`
