### PR TITLE
feat: add member reputation tracking

### DIFF
--- a/contracts/sorosave/src/contribution.rs
+++ b/contracts/sorosave/src/contribution.rs
@@ -55,6 +55,7 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
     }
 
     storage::set_round(env, group_id, &round_info);
+    storage::increment_on_time_contributions(env, &member);
 
     env.events().publish(
         (crate::symbol_short!("contrib"),),

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -74,6 +74,11 @@ impl SoroSaveContract {
         group::get_member_groups(&env, member)
     }
 
+    /// Get the aggregate on-chain reputation for a member.
+    pub fn get_reputation(env: Env, member: Address) -> MemberReputation {
+        storage::get_member_reputation(&env, &member)
+    }
+
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.

--- a/contracts/sorosave/src/payout.rs
+++ b/contracts/sorosave/src/payout.rs
@@ -39,6 +39,9 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
     if group.current_round >= group.total_rounds {
         group.status = GroupStatus::Completed;
         storage::set_group(env, &group);
+        for member in group.members.iter() {
+            storage::increment_groups_completed(env, &member);
+        }
 
         env.events()
             .publish((crate::symbol_short!("grp_comp"),), group_id);

--- a/contracts/sorosave/src/storage.rs
+++ b/contracts/sorosave/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::types::{DataKey, Dispute, RoundInfo, SavingsGroup};
+use crate::types::{DataKey, Dispute, MemberReputation, RoundInfo, SavingsGroup};
 
 const INSTANCE_TTL_THRESHOLD: u32 = 100;
 const INSTANCE_TTL_EXTEND: u32 = 500;
@@ -101,6 +101,41 @@ pub fn remove_member_group(env: &Env, member: &Address, group_id: u64) {
     }
     env.storage().persistent().set(&key, &new_groups);
     extend_persistent_ttl(env, &key);
+}
+
+// --- Member Reputation ---
+
+pub fn get_member_reputation(env: &Env, member: &Address) -> MemberReputation {
+    let key = DataKey::MemberReputation(member.clone());
+    let result = env.storage().persistent().get(&key);
+    if let Some(reputation) = result {
+        extend_persistent_ttl(env, &key);
+        reputation
+    } else {
+        MemberReputation {
+            groups_completed: 0,
+            on_time_contributions: 0,
+            defaults: 0,
+        }
+    }
+}
+
+pub fn set_member_reputation(env: &Env, member: &Address, reputation: &MemberReputation) {
+    let key = DataKey::MemberReputation(member.clone());
+    env.storage().persistent().set(&key, reputation);
+    extend_persistent_ttl(env, &key);
+}
+
+pub fn increment_on_time_contributions(env: &Env, member: &Address) {
+    let mut reputation = get_member_reputation(env, member);
+    reputation.on_time_contributions += 1;
+    set_member_reputation(env, member, &reputation);
+}
+
+pub fn increment_groups_completed(env: &Env, member: &Address) {
+    let mut reputation = get_member_reputation(env, member);
+    reputation.groups_completed += 1;
+    set_member_reputation(env, member, &reputation);
 }
 
 // --- Dispute ---

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
 
-use crate::types::GroupStatus;
+use crate::types::{GroupStatus, MemberReputation};
 use crate::{SoroSaveContract, SoroSaveContractClient};
 
 fn setup_env() -> (Env, Address, SoroSaveContractClient<'static>, Address) {
@@ -36,6 +36,13 @@ fn create_test_group(
         &86400,     // 1 day cycle
         &5,         // max 5 members
     )
+}
+
+fn mint_test_tokens(env: &Env, token: &Address, recipients: &[Address], amount: i128) {
+    let token_client = StellarAssetClient::new(env, token);
+    for recipient in recipients {
+        token_client.mint(recipient, &amount);
+    }
 }
 
 #[test]
@@ -221,4 +228,77 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+}
+
+#[test]
+fn test_reputation_defaults_to_zero() {
+    let (env, _admin, client, _token) = setup_env();
+    let outsider = Address::generate(&env);
+
+    assert_eq!(
+        client.get_reputation(&outsider),
+        MemberReputation {
+            groups_completed: 0,
+            on_time_contributions: 0,
+            defaults: 0,
+        }
+    );
+}
+
+#[test]
+fn test_reputation_updates_after_contributions_and_completion() {
+    let (env, admin, client, token) = setup_env();
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+
+    mint_test_tokens(
+        &env,
+        &token,
+        &[admin.clone(), member1.clone(), member2.clone()],
+        10_000_000,
+    );
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Reputation Group"),
+        &token,
+        &1_000_000,
+        &86400,
+        &3,
+    );
+
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.start_group(&admin, &group_id);
+
+    for round in 1..=3 {
+        client.contribute(&admin, &group_id);
+        client.contribute(&member1, &group_id);
+        client.contribute(&member2, &group_id);
+
+        assert_eq!(
+            client.get_reputation(&admin).on_time_contributions,
+            round
+        );
+        assert_eq!(
+            client.get_reputation(&member1).on_time_contributions,
+            round
+        );
+        assert_eq!(
+            client.get_reputation(&member2).on_time_contributions,
+            round
+        );
+
+        client.distribute_payout(&group_id);
+    }
+
+    let completed_reputation = MemberReputation {
+        groups_completed: 1,
+        on_time_contributions: 3,
+        defaults: 0,
+    };
+
+    assert_eq!(client.get_reputation(&admin), completed_reputation.clone());
+    assert_eq!(client.get_reputation(&member1), completed_reputation.clone());
+    assert_eq!(client.get_reputation(&member2), completed_reputation);
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -51,6 +51,15 @@ pub struct Dispute {
     pub raised_at: u64,
 }
 
+/// Aggregate contribution history for a member across groups.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct MemberReputation {
+    pub groups_completed: u32,
+    pub on_time_contributions: u32,
+    pub defaults: u32,
+}
+
 /// Storage keys for all contract data.
 #[contracttype]
 #[derive(Clone)]
@@ -60,5 +69,6 @@ pub enum DataKey {
     Group(u64),
     Round(u64, u32),
     MemberGroups(Address),
+    MemberReputation(Address),
     Dispute(u64),
 }


### PR DESCRIPTION
## Summary
- add on-chain `MemberReputation` storage keyed by member address
- track `on_time_contributions` each time a member contributes successfully
- increment `groups_completed` for all members when a group reaches completion
- expose a `get_reputation` query with zeroed defaults for members without history
- add tests covering default reputation and lifecycle-driven reputation updates

## Notes
- `defaults` is stored in the reputation model and currently remains `0` because the contract does not yet implement a default/missed-payment flow

## Testing
- `cargo test`

Closes #21