### PR TITLE
fix: distribute emergency withdraw funds proportionally

### DIFF
--- a/contracts/sorosave/src/admin.rs
+++ b/contracts/sorosave/src/admin.rs
@@ -127,16 +127,75 @@ pub fn emergency_withdraw(env: &Env, admin: Address, group_id: u64) -> Result<()
         return Err(ContractError::GroupCompleted);
     }
 
-    // Calculate remaining balance and distribute equally
     let token_client = soroban_sdk::token::Client::new(env, &group.token);
     let contract_addr = env.current_contract_address();
     let balance = token_client.balance(&contract_addr);
 
+    // Distribute remaining balance proportionally to actual historical contributions.
+    // Each recorded contribution is worth `group.contribution_amount`.
     if balance > 0 {
-        let per_member = balance / group.members.len() as i128;
-        if per_member > 0 {
+        let mut contribution_counts = soroban_sdk::Map::new(env);
+        let mut total_contributions: u32 = 0;
+
+        // Existing rounds are indexed from 1..=current_round.
+        for round_no in 1..=group.current_round {
+            if let Some(round) = storage::get_round(env, group_id, round_no) {
+                for member in group.members.iter() {
+                    if round.contributions.contains_key(member.clone()) {
+                        let prev = contribution_counts.get(member.clone()).unwrap_or(0u32);
+                        contribution_counts.set(member.clone(), prev + 1);
+                        total_contributions += 1;
+                    }
+                }
+            }
+        }
+
+        if total_contributions == 0 {
+            // No contributions recorded yet: fallback to equal split.
+            let per_member = balance / group.members.len() as i128;
+            let mut distributed: i128 = 0;
+            if per_member > 0 {
+                for member in group.members.iter() {
+                    token_client.transfer(&contract_addr, &member, &per_member);
+                    distributed += per_member;
+                }
+            }
+
+            // Flush remainder to group admin to ensure no tokens get stuck.
+            let remainder = balance - distributed;
+            if remainder > 0 {
+                token_client.transfer(&contract_addr, &group.admin, &remainder);
+            }
+        } else {
+            let mut distributed: i128 = 0;
+
             for member in group.members.iter() {
-                token_client.transfer(&contract_addr, &member, &per_member);
+                let count = contribution_counts.get(member.clone()).unwrap_or(0u32) as i128;
+                if count == 0 {
+                    continue;
+                }
+
+                let share = (balance * count) / (total_contributions as i128);
+                if share > 0 {
+                    token_client.transfer(&contract_addr, &member, &share);
+                    distributed += share;
+                }
+            }
+
+            // Flush rounding remainder to the highest-contributor address (or admin fallback).
+            let mut top_member = group.admin.clone();
+            let mut top_count = 0u32;
+            for member in group.members.iter() {
+                let c = contribution_counts.get(member.clone()).unwrap_or(0u32);
+                if c > top_count {
+                    top_count = c;
+                    top_member = member;
+                }
+            }
+
+            let remainder = balance - distributed;
+            if remainder > 0 {
+                token_client.transfer(&contract_addr, &top_member, &remainder);
             }
         }
     }

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,100 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_emergency_withdraw_unequal_contributions_proportional_and_no_stuck_funds() {
+    let (env, admin, client, _token) = setup_env();
+
+    // Create token with mint authority we control in this test.
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin.clone());
+    let token_sac = StellarAssetClient::new(&env, &token_id.address());
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let member3 = Address::generate(&env);
+    let member4 = Address::generate(&env);
+
+    for m in [admin.clone(), member1.clone(), member2.clone(), member3.clone(), member4.clone()] {
+        token_sac.mint(&m, &20_000_000);
+    }
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Emergency Withdraw Unequal"),
+        &token_id.address(),
+        &1_000_000,
+        &86400,
+        &5,
+    );
+
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.join_group(&member3, &group_id);
+    client.join_group(&member4, &group_id);
+    client.start_group(&admin, &group_id);
+
+    // Round 1: all 5 contribute.
+    client.contribute(&admin, &group_id);
+    client.contribute(&member1, &group_id);
+    client.contribute(&member2, &group_id);
+    client.contribute(&member3, &group_id);
+    client.contribute(&member4, &group_id);
+    client.distribute_payout(&group_id);
+
+    // Round 2: all 5 contribute.
+    client.contribute(&admin, &group_id);
+    client.contribute(&member1, &group_id);
+    client.contribute(&member2, &group_id);
+    client.contribute(&member3, &group_id);
+    client.contribute(&member4, &group_id);
+    client.distribute_payout(&group_id);
+
+    // Round 3 (incomplete): only admin + member1 contribute (unequal state).
+    client.contribute(&admin, &group_id);
+    client.contribute(&member1, &group_id);
+
+    let token_client = soroban_sdk::token::Client::new(&env, &token_id.address());
+    let contract_addr = client.address.clone();
+
+    // Snapshot balances before emergency withdraw.
+    let b_admin_before = token_client.balance(&admin);
+    let b_m1_before = token_client.balance(&member1);
+    let b_m2_before = token_client.balance(&member2);
+    let b_m3_before = token_client.balance(&member3);
+    let b_m4_before = token_client.balance(&member4);
+
+    let contract_before = token_client.balance(&contract_addr);
+    assert!(contract_before > 0);
+
+    // Protocol admin executes emergency withdraw.
+    client.emergency_withdraw(&admin, &group_id);
+
+    let b_admin_after = token_client.balance(&admin);
+    let b_m1_after = token_client.balance(&member1);
+    let b_m2_after = token_client.balance(&member2);
+    let b_m3_after = token_client.balance(&member3);
+    let b_m4_after = token_client.balance(&member4);
+
+    let admin_delta = b_admin_after - b_admin_before;
+    let m1_delta = b_m1_after - b_m1_before;
+    let m2_delta = b_m2_after - b_m2_before;
+    let m3_delta = b_m3_after - b_m3_before;
+    let m4_delta = b_m4_after - b_m4_before;
+
+    // admin/member1 each contributed 3 times; others 2 times.
+    assert!(admin_delta >= m2_delta);
+    assert!(m1_delta >= m2_delta);
+    assert_eq!(m2_delta, m3_delta);
+    assert_eq!(m3_delta, m4_delta);
+
+    let contract_after = token_client.balance(&contract_addr);
+    assert_eq!(contract_after, 0);
+
+    let total_distributed = admin_delta + m1_delta + m2_delta + m3_delta + m4_delta;
+    assert_eq!(total_distributed, contract_before);
+
+    let group = client.get_group(&group_id);
+    assert_eq!(group.status, GroupStatus::Completed);
+}

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -305,10 +305,14 @@ fn test_emergency_withdraw_unequal_contributions_proportional_and_no_stuck_funds
     let m4_delta = b_m4_after - b_m4_before;
 
     // admin/member1 each contributed 3 times; others 2 times.
-    assert!(admin_delta >= m2_delta);
-    assert!(m1_delta >= m2_delta);
-    assert_eq!(m2_delta, m3_delta);
-    assert_eq!(m3_delta, m4_delta);
+    // With 12 total contributions recorded, the final 2-token pot should split as:
+    // 0.5 token each to admin/member1, 0.3333333 token each to member2/3/4,
+    // plus the 0.0000001 rounding remainder to the first top contributor (admin).
+    assert_eq!(admin_delta, 500_001);
+    assert_eq!(m1_delta, 500_000);
+    assert_eq!(m2_delta, 333_333);
+    assert_eq!(m3_delta, 333_333);
+    assert_eq!(m4_delta, 333_333);
 
     let contract_after = token_client.balance(&contract_addr);
     assert_eq!(contract_after, 0);


### PR DESCRIPTION
## Problem Summary
Emergency withdraw previously split the remaining balance equally across all group members, even when only some members had actually contributed to the contract pot. That could overpay non-contributors and underpay members who had already funded more rounds.

## Solution Approach
- compute each member's share from recorded historical contributions across all rounds
- fall back to equal split only when no contributions have been recorded yet
- send any integer-division remainder to the top contributor so no tokens remain stuck
- add a deterministic test that pins the exact payout amounts for an unequal-contribution scenario

## Test Evidence
Unable to run `cargo test` on this host because Rust/Cargo is not installed in the current environment (`cargo: command not found`).

Added/updated test coverage:
- `test_emergency_withdraw_unequal_contributions_proportional_and_no_stuck_funds`

This test asserts:
- higher contributors receive higher refunds
- equal contributors receive equal refunds
- the full contract balance is distributed
- no funds remain stuck in the contract
