### PR TITLE
test: cover admin transfer permissions

### DIFF
--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,23 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_new_group_admin_can_pause_and_resume_group() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+
+    let member1 = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.join_group(&new_admin, &group_id);
+
+    client.set_group_admin(&admin, &group_id, &new_admin);
+    client.start_group(&new_admin, &group_id);
+
+    client.pause_group(&new_admin, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Paused);
+
+    client.resume_group(&new_admin, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Active);
+}


### PR DESCRIPTION
## Summary
Add coverage for the admin-transfer flow to make sure the new group admin can exercise admin-only controls after the role handoff.

## What changed
- keep the existing admin-transfer assertion
- add a follow-up test that transfers admin role and verifies the new admin can:
  - start the group
  - pause the group
  - resume the group

## Why
Issue #74 asks for test coverage around admin transfer and the permissions of the new admin. This keeps the scope small and directly checks one of the most important post-transfer behaviors.

## Test Evidence
I could not run `cargo test` in the current environment because `cargo` is not installed here.
