### PR TITLE
feat: expose total groups count

### DIFF
--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -74,6 +74,11 @@ impl SoroSaveContract {
         group::get_member_groups(&env, member)
     }
 
+    /// Expose the total number of groups ever created.
+    pub fn get_total_groups(env: Env) -> u64 {
+        storage::get_group_counter(&env)
+    }
+
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.


### PR DESCRIPTION
## Summary
- add a public `get_total_groups()` view
- return the stored group counter for lightweight stats and integrations

## Testing
- cargo test --package sorosave

Closes #61