### PR TITLE
Add get_groups_by_status view function with pagination

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -171,3 +171,33 @@ pub fn get_group(env: &Env, group_id: u64) -> Result<SavingsGroup, ContractError
 pub fn get_member_groups(env: &Env, member: Address) -> Vec<u64> {
     storage::get_member_groups(env, &member)
 }
+
+pub fn get_groups_by_status(
+    env: &Env,
+    status: GroupStatus,
+    offset: u64,
+    limit: u32,
+) -> Vec<u64> {
+    let total_groups = storage::get_group_counter(env);
+    let mut result = Vec::new(env);
+    let mut count = 0u32;
+    let mut skipped = 0u64;
+
+    for group_id in 1..=total_groups {
+        if let Some(group) = storage::get_group(env, group_id) {
+            if group.status == status {
+                if skipped < offset {
+                    skipped += 1;
+                    continue;
+                }
+                result.push_back(group_id);
+                count += 1;
+                if count >= limit {
+                    break;
+                }
+            }
+        }
+    }
+
+    result
+}

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -74,6 +74,16 @@ impl SoroSaveContract {
         group::get_member_groups(&env, member)
     }
 
+    /// Get group IDs filtered by status with pagination.
+    pub fn get_groups_by_status(
+        env: Env,
+        status: GroupStatus,
+        offset: u64,
+        limit: u32,
+    ) -> Vec<u64> {
+        group::get_groups_by_status(&env, status, offset, limit)
+    }
+
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,36 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_get_groups_by_status() {
+    let (env, admin, client, token) = setup_env();
+    
+    // Create multiple groups with different statuses
+    let group1 = create_test_group(&env, &client, &admin, &token);
+    let group2 = client.create_group(
+        &admin,
+        &String::from_str(&env, "Second Group"),
+        &token,
+        &500_000,
+        &43200,
+        &3,
+    );
+    
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group1);
+    client.start_group(&admin, &group1);
+    
+    // group1 is Active, group2 is Forming
+    let forming_groups = client.get_groups_by_status(&GroupStatus::Forming, &0, &10);
+    assert_eq!(forming_groups.len(), 1);
+    assert_eq!(forming_groups.get(0).unwrap(), group2);
+    
+    let active_groups = client.get_groups_by_status(&GroupStatus::Active, &0, &10);
+    assert_eq!(active_groups.len(), 1);
+    assert_eq!(active_groups.get(0).unwrap(), group1);
+    
+    // Test pagination
+    let all_forming = client.get_groups_by_status(&GroupStatus::Forming, &0, &1);
+    assert_eq!(all_forming.len(), 1);
+}


### PR DESCRIPTION
This PR adds a view function to query groups filtered by their current status, as requested in #65.

**Changes:**
- Add `get_groups_by_status(status, offset, limit)` function
- Returns a list of group IDs matching the given status
- Supports pagination with offset and limit parameters
- Includes test coverage for status filtering and pagination

**Use cases:**
- Frontend can efficiently list all "Forming" groups available to join
- Display "Active" groups separately from "Completed" ones
- Paginate large result sets to avoid performance issues

**Implementation:**
Iterates through all groups (1 to group_counter), filters by status, and applies pagination. This approach works well for the expected scale of groups.

Closes #65