### PR TITLE
Add token contract validation before group creation

### DIFF
--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,5 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    InvalidToken = 19,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Map, String, Vec};
+use soroban_sdk::{token, Address, Env, Map, String, Vec};
 
 use crate::errors::ContractError;
 use crate::storage;
@@ -21,6 +21,12 @@ pub fn create_group(
     if max_members < 2 {
         return Err(ContractError::InsufficientMembers);
     }
+
+    // Validate token contract exists by calling symbol()
+    let token_client = token::Client::new(env, &token);
+    token_client
+        .try_symbol()
+        .map_err(|_| ContractError::InvalidToken)?;
 
     let group_id = storage::get_group_counter(env) + 1;
     storage::set_group_counter(env, group_id);

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,27 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+#[should_panic(expected = "InvalidToken")]
+fn test_create_group_invalid_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(SoroSaveContract, (&admin,));
+    let client = SoroSaveContractClient::new(&env, &contract_id);
+
+    // Use a random address that is not a token contract
+    let invalid_token = Address::generate(&env);
+
+    // This should fail with InvalidToken error
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Test Group"),
+        &invalid_token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+}


### PR DESCRIPTION
This PR adds validation to ensure the provided token address is a valid Stellar asset contract before creating a group, as requested in #62.

**Changes:**
- Add `InvalidToken` error variant to `ContractError` enum
- Validate token contract exists by calling `symbol()` during `create_group`
- Return `InvalidToken` error if the token contract call fails
- Add test coverage for invalid token scenario

**Why this matters:**
Without this validation, groups could be created with invalid or non-existent token addresses, leading to failures later when trying to transfer tokens during contributions.

**Implementation:**
Uses `try_symbol()` to verify the token contract is callable. If the call fails (contract doesn't exist or doesn't implement the token interface), we return `InvalidToken` error immediately.

Closes #62