### PR TITLE
Add maximum group duration limit

### DIFF
--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,5 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    DurationTooLong = 19,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -4,6 +4,9 @@ use crate::errors::ContractError;
 use crate::storage;
 use crate::types::{GroupStatus, RoundInfo, SavingsGroup};
 
+// Maximum total duration for a group (365 days in seconds)
+const MAX_GROUP_DURATION: u64 = 365 * 24 * 60 * 60;
+
 pub fn create_group(
     env: &Env,
     admin: Address,
@@ -136,6 +139,12 @@ pub fn start_group(env: &Env, admin: Address, group_id: u64) -> Result<(), Contr
 
     if group.members.len() < 2 {
         return Err(ContractError::InsufficientMembers);
+    }
+
+    // Validate total duration doesn't exceed maximum
+    let total_duration = (group.members.len() as u64) * group.cycle_length;
+    if total_duration > MAX_GROUP_DURATION {
+        return Err(ContractError::DurationTooLong);
     }
 
     // Set payout order to member join order (can be randomized later)

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,58 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+#[should_panic(expected = "DurationTooLong")]
+fn test_max_group_duration() {
+    let (env, admin, client, token) = setup_env();
+    
+    // Create a group with very long cycle_length
+    // 365 days = 31,536,000 seconds
+    // With 10 members, total duration = 315,360,000 seconds (> 365 days)
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Long Duration Group"),
+        &token,
+        &1_000_000,
+        &40_000_000, // ~463 days per cycle
+        &10,
+    );
+    
+    // Add 9 more members to reach 10 total
+    for _ in 0..9 {
+        let member = Address::generate(&env);
+        client.join_group(&member, &group_id);
+    }
+    
+    // This should fail with DurationTooLong
+    client.start_group(&admin, &group_id);
+}
+
+#[test]
+fn test_valid_group_duration() {
+    let (env, admin, client, token) = setup_env();
+    
+    // Create a group with reasonable duration
+    // 30 days per cycle, 10 members = 300 days total (< 365 days)
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Valid Duration Group"),
+        &token,
+        &1_000_000,
+        &2_592_000, // 30 days
+        &10,
+    );
+    
+    // Add 9 more members
+    for _ in 0..9 {
+        let member = Address::generate(&env);
+        client.join_group(&member, &group_id);
+    }
+    
+    // This should succeed
+    client.start_group(&admin, &group_id);
+    
+    let group = client.get_group(&group_id);
+    assert_eq!(group.status, GroupStatus::Active);
+}


### PR DESCRIPTION
This PR enforces a maximum total duration for savings groups to prevent indefinitely long cycles, as requested in #55.

**Changes:**
- Add `MAX_GROUP_DURATION` constant (365 days in seconds)
- Validate `total_rounds * cycle_length <= MAX_GROUP_DURATION` during `start_group`
- Add `DurationTooLong` error variant to `ContractError`
- Return clear error if duration exceeds limit
- Add test coverage for both valid and invalid durations

**Why this matters:**
Without a duration limit, groups could theoretically run for years or decades, which:
- Increases risk for participants
- Makes planning difficult
- Could lead to abandoned groups
- Complicates dispute resolution

**Implementation:**
The validation happens in `start_group` (not `create_group`) because `total_rounds` equals the final member count, which isn't known until the group starts.

**Example:**
- 10 members × 30-day cycles = 300 days total ✅
- 10 members × 50-day cycles = 500 days total ❌ (exceeds 365-day limit)

Closes #55