### PR TITLE
Add total groups created counter view function

### DIFF
--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -74,6 +74,11 @@ impl SoroSaveContract {
         group::get_member_groups(&env, member)
     }
 
+    /// Get the total number of groups ever created.
+    pub fn get_total_groups(env: Env) -> u64 {
+        storage::get_group_counter(&env)
+    }
+
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,37 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_get_total_groups() {
+    let (env, admin, client, token) = setup_env();
+    
+    // Initially should be 0
+    assert_eq!(client.get_total_groups(), 0);
+    
+    // Create first group
+    create_test_group(&env, &client, &admin, &token);
+    assert_eq!(client.get_total_groups(), 1);
+    
+    // Create second group
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Second Group"),
+        &token,
+        &500_000,
+        &43200,
+        &3,
+    );
+    assert_eq!(client.get_total_groups(), 2);
+    
+    // Create third group
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Third Group"),
+        &token,
+        &750_000,
+        &86400,
+        &4,
+    );
+    assert_eq!(client.get_total_groups(), 3);
+}


### PR DESCRIPTION
This PR exposes the total number of groups ever created as a public view function, as requested in #61.

**Changes:**
- Add `get_total_groups() -> u64` public function
- Returns the current group counter value
- Add test coverage for counter increments across multiple group creations
- Useful for frontend stats display

**Use cases:**
- Display protocol-wide statistics on frontend
- Show "Total Groups Created: X" on landing page
- Track protocol growth over time
- Analytics and metrics dashboards

**Implementation:**
Simply exposes the existing internal `group_counter` storage value as a public read-only function.

Closes #61