### PR TITLE
Add contract test: group full scenario

### DIFF
--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,34 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+#[should_panic(expected = "GroupFull")]
+fn test_group_full_scenario() {
+    let (env, admin, client, token) = setup_env();
+    
+    // Create a group with max_members=2
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Small Group"),
+        &token,
+        &1_000_000,
+        &86400,
+        &2, // max 2 members
+    );
+    
+    // Admin is already the first member
+    let group = client.get_group(&group_id);
+    assert_eq!(group.members.len(), 1);
+    
+    // Add second member (should succeed)
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    
+    let group = client.get_group(&group_id);
+    assert_eq!(group.members.len(), 2);
+    
+    // Attempt to add third member (should fail with GroupFull)
+    let member2 = Address::generate(&env);
+    client.join_group(&member2, &group_id);
+}


### PR DESCRIPTION
This PR adds a test to verify that joining a full group returns the correct error, as requested in #27.

**Changes:**
- Add `test_group_full_scenario` test
- Create group with `max_members=2`
- Fill with 2 members (admin + one additional)
- Attempt to add 3rd member
- Verify `GroupFull` error is returned

**Test coverage:**
This test ensures the contract correctly:
- Enforces the `max_members` limit
- Returns the appropriate `GroupFull` error when capacity is reached
- Prevents over-subscription of groups

**Why this matters:**
Groups must respect their capacity limits to maintain the savings circle structure. This test validates that the contract properly rejects attempts to exceed the configured maximum.

Closes #27