### PR TITLE
Add contract test: leave group edge cases

### DIFF
--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,65 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_admin_cannot_leave_own_group() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    // Admin tries to leave their own group (should fail)
+    client.leave_group(&admin, &group_id);
+}
+
+#[test]
+#[should_panic(expected = "GroupNotForming")]
+fn test_leave_during_active_state_fails() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    
+    // Start the group (moves to Active state)
+    client.start_group(&admin, &group_id);
+    
+    // Try to leave during Active state (should fail)
+    client.leave_group(&member1, &group_id);
+}
+
+#[test]
+#[should_panic(expected = "NotMember")]
+fn test_non_member_leaving_fails() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    // Non-member tries to leave (should fail)
+    let non_member = Address::generate(&env);
+    client.leave_group(&non_member, &group_id);
+}
+
+#[test]
+fn test_leave_updates_member_groups_index() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    
+    // Verify member1 is in the group
+    let member_groups = client.get_member_groups(&member1);
+    assert_eq!(member_groups.len(), 1);
+    assert_eq!(member_groups.get(0).unwrap(), group_id);
+    
+    // Member leaves
+    client.leave_group(&member1, &group_id);
+    
+    // Verify member1 is no longer in the group
+    let member_groups = client.get_member_groups(&member1);
+    assert_eq!(member_groups.len(), 0);
+    
+    // Verify group member count decreased
+    let group = client.get_group(&group_id);
+    assert_eq!(group.members.len(), 1); // Only admin remains
+}


### PR DESCRIPTION
This PR adds comprehensive edge case tests for the `leave_group` function, as requested in #29.

**Changes:**
- Test admin cannot leave their own group → `Unauthorized` error
- Test leaving during Active state fails → `GroupNotForming` error
- Test non-member leaving fails → `NotMember` error
- Test leaving updates `member_groups` index correctly

**Test coverage:**
These tests ensure `leave_group` properly:
- Prevents admins from abandoning their own groups
- Only allows leaving during the Forming phase
- Rejects attempts from non-members
- Maintains data consistency in the member index

**Why this matters:**
The leave function has several important constraints:
- Admins must stay with their groups (they can transfer admin rights first)
- Members can only leave before the group starts
- The member index must stay in sync with group membership

These tests validate all these rules are enforced correctly.

Closes #29