### PR TITLE
Validate token contract exists before group creation

### DIFF
--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,5 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    InvalidToken = 19,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Map, String, Vec};
+use soroban_sdk::{token, Address, Env, Map, String, Vec};
 
 use crate::errors::ContractError;
 use crate::storage;
@@ -20,6 +20,12 @@ pub fn create_group(
     }
     if max_members < 2 {
         return Err(ContractError::InsufficientMembers);
+    }
+
+    // Validate token contract exists by calling its symbol() function
+    let token_client = token::TokenClient::new(env, &token);
+    if token_client.try_symbol().is_err() {
+        return Err(ContractError::InvalidToken);
     }
 
     let group_id = storage::get_group_counter(env) + 1;

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,40 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+#[should_panic(expected = "InvalidToken")]
+fn test_invalid_token_contract() {
+    let (env, admin, client, _token) = setup_env();
+    
+    // Use a random address that is not a token contract
+    let invalid_token = Address::generate(&env);
+    
+    // This should fail with InvalidToken
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Test Group"),
+        &invalid_token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+}
+
+#[test]
+fn test_valid_token_contract() {
+    let (env, admin, client, token) = setup_env();
+    
+    // This should succeed with a valid token
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Test Group"),
+        &token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    
+    let group = client.get_group(&group_id);
+    assert_eq!(group.token, token);
+}


### PR DESCRIPTION
This PR adds validation to ensure the provided token address is a valid Stellar asset contract, as requested in #62.

**Changes:**
- Call token contract's `symbol()` to verify it exists
- Return `InvalidToken` error if contract call fails
- Add `InvalidToken` variant to `ContractError` enum
- Add test coverage for both valid and invalid tokens

**Why this matters:**
Without validation, groups could be created with:
- Invalid addresses
- Non-existent contracts
- Non-token contracts

This would cause failures later when trying to transfer tokens during contributions and payouts.

**Implementation:**
Uses `try_symbol()` to safely check if the token contract exists and implements the token interface. If the call fails, we reject the group creation immediately.

**Test coverage:**
- Valid token contract → group creation succeeds
- Invalid/non-existent address → `InvalidToken` error

Closes #62