### PR TITLE
Fix: Handle edge case when all members leave during Forming

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -171,3 +171,31 @@ pub fn get_group(env: &Env, group_id: u64) -> Result<SavingsGroup, ContractError
 pub fn get_member_groups(env: &Env, member: Address) -> Vec<u64> {
     storage::get_member_groups(env, &member)
 }
+
+pub fn delete_group(env: &Env, admin: Address, group_id: u64) -> Result<(), ContractError> {
+    admin.require_auth();
+
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if admin != group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    if group.status != GroupStatus::Forming {
+        return Err(ContractError::GroupNotForming);
+    }
+
+    // Only allow deletion if only admin remains
+    if group.members.len() != 1 {
+        return Err(ContractError::InsufficientMembers);
+    }
+
+    // Clean up storage
+    storage::remove_group(env, group_id);
+    storage::remove_member_group(env, &admin, group_id);
+
+    env.events()
+        .publish((crate::symbol_short!("grp_del"),), group_id);
+
+    Ok(())
+}

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -59,6 +59,11 @@ impl SoroSaveContract {
         group::leave_group(&env, member, group_id)
     }
 
+    /// Delete a group (only allowed in Forming state with only admin remaining).
+    pub fn delete_group(env: Env, admin: Address, group_id: u64) -> Result<(), ContractError> {
+        group::delete_group(&env, admin, group_id)
+    }
+
     /// Start the group rounds. Only the group admin can call this.
     pub fn start_group(env: Env, admin: Address, group_id: u64) -> Result<(), ContractError> {
         group::start_group(&env, admin, group_id)

--- a/contracts/sorosave/src/storage.rs
+++ b/contracts/sorosave/src/storage.rs
@@ -55,6 +55,11 @@ pub fn set_group(env: &Env, group: &SavingsGroup) {
     extend_persistent_ttl(env, &key);
 }
 
+pub fn remove_group(env: &Env, group_id: u64) {
+    let key = DataKey::Group(group_id);
+    env.storage().persistent().remove(&key);
+}
+
 // --- Round ---
 
 pub fn get_round(env: &Env, group_id: u64, round: u32) -> Option<RoundInfo> {

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,65 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_delete_empty_group() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    // Add a member
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    
+    // Member leaves
+    client.leave_group(&member1, &group_id);
+    
+    // Now only admin remains, should be able to delete
+    client.delete_group(&admin, &group_id);
+    
+    // Verify group is deleted
+    assert!(client.try_get_group(&group_id).is_err());
+    
+    // Verify admin's member_groups is cleaned up
+    let member_groups = client.get_member_groups(&admin);
+    assert_eq!(member_groups.len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "InsufficientMembers")]
+fn test_delete_group_with_multiple_members() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    // Add a member
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    
+    // Try to delete with 2 members (should fail)
+    client.delete_group(&admin, &group_id);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_delete_group_non_admin() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    // Non-admin tries to delete
+    let non_admin = Address::generate(&env);
+    client.delete_group(&non_admin, &group_id);
+}
+
+#[test]
+#[should_panic(expected = "GroupNotForming")]
+fn test_delete_active_group() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    
+    let member1 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.start_group(&admin, &group_id);
+    
+    // Try to delete active group (should fail)
+    client.delete_group(&admin, &group_id);
+}


### PR DESCRIPTION
This PR fixes the edge case where all non-admin members leave a group during the Forming state, as requested in #22.

**Changes:**
- Add `delete_group(admin, group_id)` function
- Only works in Forming state with 1 member (admin)
- Clean up all storage keys (group data and member index)
- Add `remove_group` helper in `storage.rs`
- Add comprehensive test coverage

**Why this matters:**
Without this fix, if all members leave a group during Forming:
- The admin is stuck with an unusable group
- Storage is wasted on orphaned groups
- The admin can't clean up and start fresh

**Implementation:**
The `delete_group` function:
- Requires admin authorization
- Only works in Forming state
- Only works when exactly 1 member remains (the admin)
- Cleans up both the group data and member index

**Test coverage:**
- ✅ Delete empty group (only admin remains)
- ❌ Delete group with multiple members → `InsufficientMembers`
- ❌ Non-admin tries to delete → `Unauthorized`
- ❌ Delete active group → `GroupNotForming`

Closes #22