### PR TITLE
Add maximum group duration limit

### DIFF
--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,5 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    DurationTooLong = 19,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -4,6 +4,9 @@ use crate::errors::ContractError;
 use crate::storage;
 use crate::types::{GroupStatus, RoundInfo, SavingsGroup};
 
+// Maximum group duration: 365 days in seconds
+const MAX_GROUP_DURATION: u64 = 365 * 24 * 60 * 60;
+
 pub fn create_group(
     env: &Env,
     admin: Address,
@@ -20,6 +23,13 @@ pub fn create_group(
     }
     if max_members < 2 {
         return Err(ContractError::InsufficientMembers);
+    }
+
+    // Validate maximum group duration
+    // Total duration = max_members * cycle_length (worst case: all members)
+    let total_duration = (max_members as u64) * cycle_length;
+    if total_duration > MAX_GROUP_DURATION {
+        return Err(ContractError::DurationTooLong);
     }
 
     let group_id = storage::get_group_counter(env) + 1;

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,71 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_valid_group_duration() {
+    let (env, admin, client, token) = setup_env();
+    
+    // 5 members * 30 days = 150 days (valid)
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Valid Duration Group"),
+        &token,
+        &1_000_000,
+        &(30 * 24 * 60 * 60), // 30 days
+        &5,
+    );
+    
+    let group = client.get_group(&group_id);
+    assert_eq!(group.max_members, 5);
+}
+
+#[test]
+#[should_panic(expected = "DurationTooLong")]
+fn test_duration_exceeds_limit() {
+    let (env, admin, client, token) = setup_env();
+    
+    // 100 members * 10 days = 1000 days (exceeds 365 day limit)
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Too Long Group"),
+        &token,
+        &1_000_000,
+        &(10 * 24 * 60 * 60), // 10 days
+        &100, // 100 members
+    );
+}
+
+#[test]
+#[should_panic(expected = "DurationTooLong")]
+fn test_duration_at_boundary() {
+    let (env, admin, client, token) = setup_env();
+    
+    // 366 members * 1 day = 366 days (just over limit)
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Boundary Group"),
+        &token,
+        &1_000_000,
+        &(24 * 60 * 60), // 1 day
+        &366,
+    );
+}
+
+#[test]
+fn test_duration_exactly_at_limit() {
+    let (env, admin, client, token) = setup_env();
+    
+    // 365 members * 1 day = 365 days (exactly at limit, should pass)
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Max Duration Group"),
+        &token,
+        &1_000_000,
+        &(24 * 60 * 60), // 1 day
+        &365,
+    );
+    
+    let group = client.get_group(&group_id);
+    assert_eq!(group.max_members, 365);
+}


### PR DESCRIPTION
This PR adds a maximum group duration limit to prevent indefinitely long savings cycles, as requested in #55.

**Changes:**
- Add `MAX_GROUP_DURATION` constant (365 days)
- Validate `total_rounds * cycle_length <= max_duration` during `create_group`
- Add `DurationTooLong` error variant
- Return clear error if duration exceeds limit
- Add comprehensive test coverage

**Why this matters:**
Without a duration limit:
- Groups could run for years or decades
- Members would be locked in for unreasonable timeframes
- Storage costs would accumulate indefinitely
- Risk of abandoned groups increases

**Implementation:**
The validation calculates worst-case duration as:
```
total_duration = max_members * cycle_length
```

This assumes all members join (which determines total_rounds). If the total exceeds 365 days, group creation fails with `DurationTooLong`.

**Test coverage:**
- ✅ Valid duration (5 members × 30 days = 150 days)
- ❌ Duration exceeds limit (100 members × 10 days = 1000 days) → `DurationTooLong`
- ❌ Just over boundary (366 members × 1 day) → `DurationTooLong`
- ✅ Exactly at limit (365 members × 1 day = 365 days)

Closes #55