### PR TITLE
Validate token contract exists before group creation

### DIFF
--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,5 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    InvalidToken = 19,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -22,6 +22,12 @@ pub fn create_group(
         return Err(ContractError::InsufficientMembers);
     }
 
+    // Validate token contract exists by calling symbol()
+    let token_client = soroban_sdk::token::Client::new(env, &token);
+    if token_client.try_symbol().is_err() {
+        return Err(ContractError::InvalidToken);
+    }
+
     let group_id = storage::get_group_counter(env) + 1;
     storage::set_group_counter(env, group_id);
 

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -222,3 +222,59 @@ fn test_set_group_admin() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
 }
+
+#[test]
+fn test_valid_token_contract() {
+    let (env, admin, client, token) = setup_env();
+    
+    // Create group with valid token (should succeed)
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Valid Token Group"),
+        &token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    
+    let group = client.get_group(&group_id);
+    assert_eq!(group.token, token);
+}
+
+#[test]
+#[should_panic(expected = "InvalidToken")]
+fn test_invalid_token_contract() {
+    let (env, admin, client, _token) = setup_env();
+    
+    // Use a random address that's not a token contract
+    let invalid_token = Address::generate(&env);
+    
+    // Try to create group with invalid token (should fail)
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Invalid Token Group"),
+        &invalid_token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+}
+
+#[test]
+#[should_panic(expected = "InvalidToken")]
+fn test_non_existent_token_contract() {
+    let (env, admin, client, _token) = setup_env();
+    
+    // Use the contract's own address (not a token)
+    let non_token = client.address.clone();
+    
+    // Try to create group with non-token contract (should fail)
+    client.create_group(
+        &admin,
+        &String::from_str(&env, "Non-Token Group"),
+        &non_token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+}


### PR DESCRIPTION
This PR adds validation to ensure the provided token address is a valid Stellar asset contract, as requested in #62.

**Changes:**
- Call token contract's `symbol()` to verify it exists
- Return `InvalidToken` error if contract call fails
- Add `InvalidToken` variant to ContractError enum
- Add test coverage for valid and invalid tokens

**Why this matters:**
Without validation:
- Groups could be created with invalid token addresses
- Contributions would fail later with cryptic errors
- Users would waste gas on broken groups
- Contract state would be polluted with unusable groups

**Implementation:**
Uses `try_symbol()` to safely check if the token contract exists and implements the token interface. If the call fails, group creation is rejected with `InvalidToken`.

**Test coverage:**
- ✅ Valid token contract → group created successfully
- ❌ Random address (not a contract) → `InvalidToken`
- ❌ Non-token contract address → `InvalidToken`

Closes #62