### PR TITLE
Add flexible payout schedules

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -2,7 +2,20 @@ use soroban_sdk::{Address, Env, Map, String, Vec};
 
 use crate::errors::ContractError;
 use crate::storage;
-use crate::types::{GroupStatus, RoundInfo, SavingsGroup};
+use crate::types::{GroupStatus, PayoutSchedule, RoundInfo, SavingsGroup};
+
+const WEEKLY_SECONDS: u64 = 7 * 24 * 60 * 60;
+const BIWEEKLY_SECONDS: u64 = 14 * 24 * 60 * 60;
+const MONTHLY_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+struct GroupCreation {
+    name: String,
+    token: Address,
+    contribution_amount: i128,
+    payout_schedule: PayoutSchedule,
+    cycle_length: u64,
+    max_members: u32,
+}
 
 pub fn create_group(
     env: &Env,
@@ -13,12 +26,55 @@ pub fn create_group(
     cycle_length: u64,
     max_members: u32,
 ) -> Result<u64, ContractError> {
+    create_group_from_config(
+        env,
+        admin,
+        GroupCreation {
+            name,
+            token,
+            contribution_amount,
+            payout_schedule: PayoutSchedule::Custom,
+            cycle_length,
+            max_members,
+        },
+    )
+}
+
+pub fn create_group_with_schedule(
+    env: &Env,
+    admin: Address,
+    name: String,
+    token: Address,
+    contribution_amount: i128,
+    payout_schedule: PayoutSchedule,
+    max_members: u32,
+) -> Result<u64, ContractError> {
+    let cycle_length = cycle_length_for_schedule(&payout_schedule)?;
+    create_group_from_config(
+        env,
+        admin,
+        GroupCreation {
+            name,
+            token,
+            contribution_amount,
+            payout_schedule,
+            cycle_length,
+            max_members,
+        },
+    )
+}
+
+fn create_group_from_config(
+    env: &Env,
+    admin: Address,
+    config: GroupCreation,
+) -> Result<u64, ContractError> {
     admin.require_auth();
 
-    if contribution_amount <= 0 {
+    if config.contribution_amount <= 0 {
         return Err(ContractError::InvalidAmount);
     }
-    if max_members < 2 {
+    if config.max_members < 2 {
         return Err(ContractError::InsufficientMembers);
     }
 
@@ -30,12 +86,13 @@ pub fn create_group(
 
     let group = SavingsGroup {
         id: group_id,
-        name,
+        name: config.name,
         admin: admin.clone(),
-        token,
-        contribution_amount,
-        cycle_length,
-        max_members,
+        token: config.token,
+        contribution_amount: config.contribution_amount,
+        payout_schedule: config.payout_schedule,
+        cycle_length: config.cycle_length,
+        max_members: config.max_members,
         members,
         payout_order: Vec::new(env),
         current_round: 0,
@@ -51,6 +108,15 @@ pub fn create_group(
         .publish((crate::symbol_short!("grp_creat"),), group_id);
 
     Ok(group_id)
+}
+
+fn cycle_length_for_schedule(schedule: &PayoutSchedule) -> Result<u64, ContractError> {
+    match schedule {
+        PayoutSchedule::Weekly => Ok(WEEKLY_SECONDS),
+        PayoutSchedule::Biweekly => Ok(BIWEEKLY_SECONDS),
+        PayoutSchedule::Monthly => Ok(MONTHLY_SECONDS),
+        PayoutSchedule::Custom => Err(ContractError::InvalidAmount),
+    }
 }
 
 pub fn join_group(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -49,6 +49,28 @@ impl SoroSaveContract {
         )
     }
 
+    /// Create a new savings group using a preset payout schedule.
+    /// Custom schedules preserve the caller-provided cycle length.
+    pub fn create_group_with_schedule(
+        env: Env,
+        admin: Address,
+        name: String,
+        token: Address,
+        contribution_amount: i128,
+        payout_schedule: PayoutSchedule,
+        max_members: u32,
+    ) -> Result<u64, ContractError> {
+        group::create_group_with_schedule(
+            &env,
+            admin,
+            name,
+            token,
+            contribution_amount,
+            payout_schedule,
+            max_members,
+        )
+    }
+
     /// Join an existing group that is still forming.
     pub fn join_group(env: Env, member: Address, group_id: u64) -> Result<(), ContractError> {
         group::join_group(&env, member, group_id)

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
 
-use crate::types::GroupStatus;
+use crate::types::{GroupStatus, PayoutSchedule};
 use crate::{SoroSaveContract, SoroSaveContractClient};
 
 fn setup_env() -> (Env, Address, SoroSaveContractClient<'static>, Address) {
@@ -47,9 +47,52 @@ fn test_create_group() {
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, admin);
     assert_eq!(group.contribution_amount, 1_000_000);
+    assert_eq!(group.payout_schedule, PayoutSchedule::Custom);
     assert_eq!(group.max_members, 5);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
+}
+
+#[test]
+fn test_create_group_with_preset_schedule() {
+    let (env, admin, client, token) = setup_env();
+
+    let weekly_id = client.create_group_with_schedule(
+        &admin,
+        &String::from_str(&env, "Weekly Group"),
+        &token,
+        &1_000_000,
+        &PayoutSchedule::Weekly,
+        &5,
+    );
+    let biweekly_id = client.create_group_with_schedule(
+        &admin,
+        &String::from_str(&env, "Biweekly Group"),
+        &token,
+        &1_000_000,
+        &PayoutSchedule::Biweekly,
+        &5,
+    );
+    let monthly_id = client.create_group_with_schedule(
+        &admin,
+        &String::from_str(&env, "Monthly Group"),
+        &token,
+        &1_000_000,
+        &PayoutSchedule::Monthly,
+        &5,
+    );
+
+    let weekly = client.get_group(&weekly_id);
+    assert_eq!(weekly.payout_schedule, PayoutSchedule::Weekly);
+    assert_eq!(weekly.cycle_length, 604_800);
+
+    let biweekly = client.get_group(&biweekly_id);
+    assert_eq!(biweekly.payout_schedule, PayoutSchedule::Biweekly);
+    assert_eq!(biweekly.cycle_length, 1_209_600);
+
+    let monthly = client.get_group(&monthly_id);
+    assert_eq!(monthly.payout_schedule, PayoutSchedule::Monthly);
+    assert_eq!(monthly.cycle_length, 2_592_000);
 }
 
 #[test]

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -11,6 +11,16 @@ pub enum GroupStatus {
     Paused,    // Admin has paused the group
 }
 
+/// Preset payout cadence options for a savings group.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum PayoutSchedule {
+    Weekly,
+    Biweekly,
+    Monthly,
+    Custom,
+}
+
 /// Core savings group configuration and state.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -20,6 +30,7 @@ pub struct SavingsGroup {
     pub admin: Address,
     pub token: Address,
     pub contribution_amount: i128,
+    pub payout_schedule: PayoutSchedule,
     pub cycle_length: u64,
     pub max_members: u32,
     pub members: Vec<Address>,


### PR DESCRIPTION
## Summary
- add `PayoutSchedule` with weekly, biweekly, monthly, and custom schedule states
- keep existing `create_group` custom cycle-length behavior intact
- add `create_group_with_schedule` for preset schedule creation and map presets to cycle lengths
- cover preset schedule creation and custom backward-compatible creation in tests

Closes #44

## Verification
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`