### PR TITLE
Add delegated contribution support

### DIFF
--- a/contracts/sorosave/src/contribution.rs
+++ b/contracts/sorosave/src/contribution.rs
@@ -6,24 +6,73 @@ use crate::types::{GroupStatus, RoundInfo};
 
 pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {
     member.require_auth();
+    contribute_for_member(env, member.clone(), member, group_id)
+}
 
+pub fn set_delegate(
+    env: &Env,
+    member: Address,
+    delegate: Address,
+    group_id: u64,
+) -> Result<(), ContractError> {
+    member.require_auth();
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    ensure_member(&group.members, &member)?;
+
+    storage::set_delegate(env, group_id, &member, &delegate);
+    env.events().publish(
+        (crate::symbol_short!("delegate"),),
+        (group_id, member, delegate),
+    );
+
+    Ok(())
+}
+
+pub fn revoke_delegate(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {
+    member.require_auth();
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    ensure_member(&group.members, &member)?;
+
+    storage::remove_delegate(env, group_id, &member);
+    env.events()
+        .publish((crate::symbol_short!("del_rev"),), (group_id, member));
+
+    Ok(())
+}
+
+pub fn get_delegate(env: &Env, member: Address, group_id: u64) -> Option<Address> {
+    storage::get_delegate(env, group_id, &member)
+}
+
+pub fn contribute_for(
+    env: &Env,
+    delegate: Address,
+    member: Address,
+    group_id: u64,
+) -> Result<(), ContractError> {
+    delegate.require_auth();
+    let active_delegate =
+        storage::get_delegate(env, group_id, &member).ok_or(ContractError::Unauthorized)?;
+    if active_delegate != delegate {
+        return Err(ContractError::Unauthorized);
+    }
+
+    contribute_for_member(env, delegate, member, group_id)
+}
+
+fn contribute_for_member(
+    env: &Env,
+    payer: Address,
+    member: Address,
+    group_id: u64,
+) -> Result<(), ContractError> {
     let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
     if group.status != GroupStatus::Active {
         return Err(ContractError::GroupNotActive);
     }
 
-    // Verify membership
-    let mut is_member = false;
-    for m in group.members.iter() {
-        if m == member {
-            is_member = true;
-            break;
-        }
-    }
-    if !is_member {
-        return Err(ContractError::NotMember);
-    }
+    ensure_member(&group.members, &member)?;
 
     let mut round_info = storage::get_round(env, group_id, group.current_round)
         .ok_or(ContractError::RoundNotActive)?;
@@ -40,7 +89,7 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
     // Transfer tokens from member to this contract
     let token_client = soroban_sdk::token::Client::new(env, &group.token);
     token_client.transfer(
-        &member,
+        &payer,
         &env.current_contract_address(),
         &group.contribution_amount,
     );
@@ -62,6 +111,18 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
     );
 
     Ok(())
+}
+
+fn ensure_member(
+    members: &soroban_sdk::Vec<Address>,
+    member: &Address,
+) -> Result<(), ContractError> {
+    for group_member in members.iter() {
+        if group_member == *member {
+            return Ok(());
+        }
+    }
+    Err(ContractError::NotMember)
 }
 
 pub fn get_round_status(env: &Env, group_id: u64, round: u32) -> Result<RoundInfo, ContractError> {

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -81,6 +81,36 @@ impl SoroSaveContract {
         contribution::contribute(&env, member, group_id)
     }
 
+    /// Authorize a delegate to contribute on behalf of a group member.
+    pub fn set_delegate(
+        env: Env,
+        member: Address,
+        delegate: Address,
+        group_id: u64,
+    ) -> Result<(), ContractError> {
+        contribution::set_delegate(&env, member, delegate, group_id)
+    }
+
+    /// Revoke the active delegate for a group member.
+    pub fn revoke_delegate(env: Env, member: Address, group_id: u64) -> Result<(), ContractError> {
+        contribution::revoke_delegate(&env, member, group_id)
+    }
+
+    /// Get the active delegate for a group member.
+    pub fn get_delegate(env: Env, member: Address, group_id: u64) -> Option<Address> {
+        contribution::get_delegate(&env, member, group_id)
+    }
+
+    /// Contribute as an authorized delegate and credit the member's round.
+    pub fn contribute_for(
+        env: Env,
+        delegate: Address,
+        member: Address,
+        group_id: u64,
+    ) -> Result<(), ContractError> {
+        contribution::contribute_for(&env, delegate, member, group_id)
+    }
+
     /// Get the status of a specific round.
     pub fn get_round_status(
         env: Env,

--- a/contracts/sorosave/src/storage.rs
+++ b/contracts/sorosave/src/storage.rs
@@ -103,6 +103,28 @@ pub fn remove_member_group(env: &Env, member: &Address, group_id: u64) {
     extend_persistent_ttl(env, &key);
 }
 
+// --- Delegates ---
+
+pub fn get_delegate(env: &Env, group_id: u64, member: &Address) -> Option<Address> {
+    let key = DataKey::Delegate(group_id, member.clone());
+    let result = env.storage().persistent().get(&key);
+    if result.is_some() {
+        extend_persistent_ttl(env, &key);
+    }
+    result
+}
+
+pub fn set_delegate(env: &Env, group_id: u64, member: &Address, delegate: &Address) {
+    let key = DataKey::Delegate(group_id, member.clone());
+    env.storage().persistent().set(&key, delegate);
+    extend_persistent_ttl(env, &key);
+}
+
+pub fn remove_delegate(env: &Env, group_id: u64, member: &Address) {
+    let key = DataKey::Delegate(group_id, member.clone());
+    env.storage().persistent().remove(&key);
+}
+
 // --- Dispute ---
 
 #[allow(dead_code)]

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -152,6 +152,48 @@ fn test_full_cycle() {
 }
 
 #[test]
+fn test_delegate_can_contribute_for_member() {
+    let (env, admin, client, _token) = setup_env();
+    let member = Address::generate(&env);
+    let delegate = Address::generate(&env);
+
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin);
+    let token_sac = StellarAssetClient::new(&env, &token_id.address());
+    token_sac.mint(&admin, &10_000_000);
+    token_sac.mint(&delegate, &10_000_000);
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Delegated Contributions"),
+        &token_id.address(),
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    client.join_group(&member, &group_id);
+
+    client.set_delegate(&member, &delegate, &group_id);
+    assert_eq!(
+        client.get_delegate(&member, &group_id),
+        Some(delegate.clone())
+    );
+
+    client.start_group(&admin, &group_id);
+    client.contribute_for(&delegate, &member, &group_id);
+
+    assert!(client.has_contributed(&member, &group_id, &1));
+    let round = client.get_round_status(&group_id, &1);
+    assert_eq!(round.total_contributed, 1_000_000);
+
+    client.contribute(&admin, &group_id);
+    assert!(client.get_round_status(&group_id, &1).is_complete);
+
+    client.revoke_delegate(&member, &group_id);
+    assert_eq!(client.get_delegate(&member, &group_id), None);
+}
+
+#[test]
 fn test_member_groups() {
     let (env, admin, client, token) = setup_env();
 

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -60,5 +60,6 @@ pub enum DataKey {
     Group(u64),
     Round(u64, u32),
     MemberGroups(Address),
+    Delegate(u64, Address),
     Dispute(u64),
 }


### PR DESCRIPTION
## Summary
- add per-member per-group delegate storage
- add `set_delegate`, `revoke_delegate`, and `get_delegate` contract methods
- add `contribute_for` so an authorized delegate can pay and credit the member's current round
- keep normal direct member contribution behavior unchanged
- cover delegated contribution, delegate lookup, and revocation in tests

Closes #56

## Verification
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`