### PR TITLE
Add auto-restart groups

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -37,10 +37,12 @@ pub fn create_group(
         cycle_length,
         max_members,
         members,
+        next_cycle_opt_outs: Vec::new(env),
         payout_order: Vec::new(env),
         current_round: 0,
         total_rounds: 0,
         status: GroupStatus::Forming,
+        auto_restart: false,
         created_at: env.ledger().timestamp(),
     };
 
@@ -170,4 +172,62 @@ pub fn get_group(env: &Env, group_id: u64) -> Result<SavingsGroup, ContractError
 
 pub fn get_member_groups(env: &Env, member: Address) -> Vec<u64> {
     storage::get_member_groups(env, &member)
+}
+
+pub fn set_auto_restart(
+    env: &Env,
+    admin: Address,
+    group_id: u64,
+    auto_restart: bool,
+) -> Result<(), ContractError> {
+    admin.require_auth();
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if admin != group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    group.auto_restart = auto_restart;
+    storage::set_group(env, &group);
+
+    env.events().publish(
+        (crate::symbol_short!("auto_rst"),),
+        (group_id, auto_restart),
+    );
+
+    Ok(())
+}
+
+pub fn opt_out_next_cycle(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {
+    member.require_auth();
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if group.status != GroupStatus::Active {
+        return Err(ContractError::GroupNotActive);
+    }
+
+    let mut is_member = false;
+    for group_member in group.members.iter() {
+        if group_member == member {
+            is_member = true;
+            break;
+        }
+    }
+    if !is_member {
+        return Err(ContractError::NotMember);
+    }
+
+    for opted_out in group.next_cycle_opt_outs.iter() {
+        if opted_out == member {
+            return Ok(());
+        }
+    }
+
+    group.next_cycle_opt_outs.push_back(member.clone());
+    storage::set_group(env, &group);
+
+    env.events()
+        .publish((crate::symbol_short!("opt_out"),), (group_id, member));
+
+    Ok(())
 }

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -74,6 +74,25 @@ impl SoroSaveContract {
         group::get_member_groups(&env, member)
     }
 
+    /// Configure whether a group restarts after its final round completes.
+    pub fn set_auto_restart(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        auto_restart: bool,
+    ) -> Result<(), ContractError> {
+        group::set_auto_restart(&env, admin, group_id, auto_restart)
+    }
+
+    /// Opt a member out of the next automatically restarted cycle.
+    pub fn opt_out_next_cycle(
+        env: Env,
+        member: Address,
+        group_id: u64,
+    ) -> Result<(), ContractError> {
+        group::opt_out_next_cycle(&env, member, group_id)
+    }
+
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.

--- a/contracts/sorosave/src/payout.rs
+++ b/contracts/sorosave/src/payout.rs
@@ -35,13 +35,17 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
         ),
     );
 
-    // Advance to next round or complete the group
+    // Advance to next round, restart the group, or complete the group.
     if group.current_round >= group.total_rounds {
-        group.status = GroupStatus::Completed;
-        storage::set_group(env, &group);
+        if group.auto_restart {
+            restart_group(env, &mut group, group_id);
+        } else {
+            group.status = GroupStatus::Completed;
+            storage::set_group(env, &group);
 
-        env.events()
-            .publish((crate::symbol_short!("grp_comp"),), group_id);
+            env.events()
+                .publish((crate::symbol_short!("grp_comp"),), group_id);
+        }
     } else {
         group.current_round += 1;
         let next_recipient = group.payout_order.get(group.current_round - 1).unwrap();
@@ -65,6 +69,74 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
     }
 
     Ok(())
+}
+
+fn restart_group(env: &Env, group: &mut crate::types::SavingsGroup, group_id: u64) {
+    let mut next_members = Vec::new(env);
+    for member in group.members.iter() {
+        let mut opted_out = false;
+        for opt_out in group.next_cycle_opt_outs.iter() {
+            if opt_out == member {
+                opted_out = true;
+                break;
+            }
+        }
+        if !opted_out {
+            next_members.push_back(member);
+        }
+    }
+
+    if next_members.len() < 2 {
+        group.status = GroupStatus::Completed;
+        group.next_cycle_opt_outs = Vec::new(env);
+        storage::set_group(env, group);
+        env.events()
+            .publish((crate::symbol_short!("grp_comp"),), group_id);
+        return;
+    }
+
+    group.members = next_members.clone();
+    group.payout_order = rotate_payout_order(env, &next_members);
+    group.next_cycle_opt_outs = Vec::new(env);
+    group.current_round = 1;
+    group.total_rounds = group.members.len();
+    group.status = GroupStatus::Active;
+
+    let first_recipient = group.payout_order.get(0).unwrap();
+    let first_round = RoundInfo {
+        round_number: 1,
+        recipient: first_recipient,
+        contributions: Map::new(env),
+        total_contributed: 0,
+        is_complete: false,
+        deadline: env.ledger().timestamp() + group.cycle_length,
+    };
+
+    storage::set_round(env, group_id, &first_round);
+    storage::set_group(env, group);
+
+    env.events().publish(
+        (crate::symbol_short!("grp_rstr"),),
+        (group_id, group.total_rounds),
+    );
+}
+
+fn rotate_payout_order(env: &Env, members: &Vec<Address>) -> Vec<Address> {
+    let mut payout_order = Vec::new(env);
+    if members.is_empty() {
+        return payout_order;
+    }
+
+    for index in 1..members.len() {
+        if let Some(member) = members.get(index) {
+            payout_order.push_back(member);
+        }
+    }
+    if let Some(first_member) = members.get(0) {
+        payout_order.push_back(first_member);
+    }
+
+    payout_order
 }
 
 pub fn get_payout_order(env: &Env, group_id: u64) -> Result<Vec<Address>, ContractError> {

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -50,6 +50,8 @@ fn test_create_group() {
     assert_eq!(group.max_members, 5);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
+    assert!(!group.auto_restart);
+    assert_eq!(group.next_cycle_opt_outs.len(), 0);
 }
 
 #[test]
@@ -149,6 +151,60 @@ fn test_full_cycle() {
     // Group should be completed
     let group = client.get_group(&group_id);
     assert_eq!(group.status, GroupStatus::Completed);
+}
+
+#[test]
+fn test_auto_restarts_group_after_final_round() {
+    let (env, admin, client, _token) = setup_env();
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let member3 = Address::generate(&env);
+
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin);
+    let token_sac = StellarAssetClient::new(&env, &token_id.address());
+    for member in [&admin, &member1, &member2, &member3] {
+        token_sac.mint(member, &10_000_000);
+    }
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Auto Restart Group"),
+        &token_id.address(),
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.join_group(&member3, &group_id);
+    client.set_auto_restart(&admin, &group_id, &true);
+    client.start_group(&admin, &group_id);
+
+    client.opt_out_next_cycle(&member3, &group_id);
+
+    for _round in 1..=4 {
+        client.contribute(&admin, &group_id);
+        client.contribute(&member1, &group_id);
+        client.contribute(&member2, &group_id);
+        client.contribute(&member3, &group_id);
+        client.distribute_payout(&group_id);
+    }
+
+    let group = client.get_group(&group_id);
+    assert_eq!(group.status, GroupStatus::Active);
+    assert!(group.auto_restart);
+    assert_eq!(group.members.len(), 3);
+    assert_eq!(group.total_rounds, 3);
+    assert_eq!(group.current_round, 1);
+    assert_eq!(group.next_cycle_opt_outs.len(), 0);
+    assert_eq!(group.payout_order.get(0).unwrap(), member1);
+    assert_eq!(group.payout_order.get(1).unwrap(), member2);
+    assert_eq!(group.payout_order.get(2).unwrap(), admin);
+
+    let new_round = client.get_round_status(&group_id, &1);
+    assert!(!new_round.is_complete);
+    assert_eq!(new_round.recipient, member1);
 }
 
 #[test]

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -23,10 +23,12 @@ pub struct SavingsGroup {
     pub cycle_length: u64,
     pub max_members: u32,
     pub members: Vec<Address>,
+    pub next_cycle_opt_outs: Vec<Address>,
     pub payout_order: Vec<Address>,
     pub current_round: u32,
     pub total_rounds: u32,
     pub status: GroupStatus,
+    pub auto_restart: bool,
     pub created_at: u64,
 }
 


### PR DESCRIPTION
## Summary
- add auto-restart state to savings groups with an admin toggle
- add member opt-out tracking for the next cycle
- restart a completed group when auto-restart is enabled and at least two members remain
- rotate the payout order for the new cycle and initialize the first new round
- cover auto-restart with member opt-out in tests

Closes #16

## Verification
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`