### PR TITLE
Add partial contribution support

### DIFF
--- a/contracts/sorosave/src/contribution.rs
+++ b/contracts/sorosave/src/contribution.rs
@@ -5,7 +5,20 @@ use crate::storage;
 use crate::types::{GroupStatus, RoundInfo};
 
 pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    contribute_partial(env, member, group_id, group.contribution_amount)
+}
+
+pub fn contribute_partial(
+    env: &Env,
+    member: Address,
+    group_id: u64,
+    amount: i128,
+) -> Result<(), ContractError> {
     member.require_auth();
+    if amount <= 0 {
+        return Err(ContractError::InvalidAmount);
+    }
 
     let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
@@ -32,22 +45,31 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
         return Err(ContractError::RoundNotActive);
     }
 
-    // Check if already contributed this round
     if round_info.contributions.contains_key(member.clone()) {
         return Err(ContractError::AlreadyContributed);
+    }
+    let current_progress = round_info
+        .contribution_amounts
+        .get(member.clone())
+        .unwrap_or(0);
+    let remaining = group.contribution_amount - current_progress;
+    if amount > remaining {
+        return Err(ContractError::InvalidAmount);
     }
 
     // Transfer tokens from member to this contract
     let token_client = soroban_sdk::token::Client::new(env, &group.token);
-    token_client.transfer(
-        &member,
-        &env.current_contract_address(),
-        &group.contribution_amount,
-    );
+    token_client.transfer(&member, &env.current_contract_address(), &amount);
 
     // Record contribution
-    round_info.contributions.set(member.clone(), true);
-    round_info.total_contributed += group.contribution_amount;
+    let new_progress = current_progress + amount;
+    round_info
+        .contribution_amounts
+        .set(member.clone(), new_progress);
+    round_info.total_contributed += amount;
+    if new_progress == group.contribution_amount {
+        round_info.contributions.set(member.clone(), true);
+    }
 
     // Check if all members have contributed
     if round_info.contributions.len() == group.members.len() {
@@ -58,7 +80,7 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
 
     env.events().publish(
         (crate::symbol_short!("contrib"),),
-        (group_id, member, group.contribution_amount),
+        (group_id, member, amount, new_progress),
     );
 
     Ok(())
@@ -77,4 +99,15 @@ pub fn has_contributed(
     let round_info =
         storage::get_round(env, group_id, round).ok_or(ContractError::RoundNotActive)?;
     Ok(round_info.contributions.contains_key(member))
+}
+
+pub fn get_member_contribution_progress(
+    env: &Env,
+    member: Address,
+    group_id: u64,
+    round: u32,
+) -> Result<i128, ContractError> {
+    let round_info =
+        storage::get_round(env, group_id, round).ok_or(ContractError::RoundNotActive)?;
+    Ok(round_info.contribution_amounts.get(member).unwrap_or(0))
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -150,6 +150,7 @@ pub fn start_group(env: &Env, admin: Address, group_id: u64) -> Result<(), Contr
         round_number: 1,
         recipient: first_recipient,
         contributions: Map::new(env),
+        contribution_amounts: Map::new(env),
         total_contributed: 0,
         is_complete: false,
         deadline: env.ledger().timestamp() + group.cycle_length,

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -81,6 +81,16 @@ impl SoroSaveContract {
         contribution::contribute(&env, member, group_id)
     }
 
+    /// Contribute part of the required amount to the current round of a group.
+    pub fn contribute_partial(
+        env: Env,
+        member: Address,
+        group_id: u64,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        contribution::contribute_partial(&env, member, group_id, amount)
+    }
+
     /// Get the status of a specific round.
     pub fn get_round_status(
         env: Env,
@@ -98,6 +108,16 @@ impl SoroSaveContract {
         round: u32,
     ) -> Result<bool, ContractError> {
         contribution::has_contributed(&env, member, group_id, round)
+    }
+
+    /// Get a member's cumulative contribution amount for a round.
+    pub fn get_member_contribution_progress(
+        env: Env,
+        member: Address,
+        group_id: u64,
+        round: u32,
+    ) -> Result<i128, ContractError> {
+        contribution::get_member_contribution_progress(&env, member, group_id, round)
     }
 
     // ─── Payouts ────────────────────────────────────────────────────

--- a/contracts/sorosave/src/payout.rs
+++ b/contracts/sorosave/src/payout.rs
@@ -50,6 +50,7 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
             round_number: group.current_round,
             recipient: next_recipient,
             contributions: Map::new(env),
+            contribution_amounts: Map::new(env),
             total_contributed: 0,
             is_complete: false,
             deadline: env.ledger().timestamp() + group.cycle_length,

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -152,6 +152,49 @@ fn test_full_cycle() {
 }
 
 #[test]
+fn test_partial_contributions_accumulate_until_complete() {
+    let (env, admin, client, _token) = setup_env();
+    let member1 = Address::generate(&env);
+
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin);
+    let token_sac = StellarAssetClient::new(&env, &token_id.address());
+    token_sac.mint(&admin, &10_000_000);
+    token_sac.mint(&member1, &10_000_000);
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Partial Contributions"),
+        &token_id.address(),
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    client.join_group(&member1, &group_id);
+    client.start_group(&admin, &group_id);
+
+    client.contribute_partial(&member1, &group_id, &400_000);
+    assert_eq!(
+        client.get_member_contribution_progress(&member1, &group_id, &1),
+        400_000
+    );
+    assert!(!client.has_contributed(&member1, &group_id, &1));
+    assert!(!client.get_round_status(&group_id, &1).is_complete);
+
+    client.contribute_partial(&member1, &group_id, &600_000);
+    assert_eq!(
+        client.get_member_contribution_progress(&member1, &group_id, &1),
+        1_000_000
+    );
+    assert!(client.has_contributed(&member1, &group_id, &1));
+
+    client.contribute(&admin, &group_id);
+    let round = client.get_round_status(&group_id, &1);
+    assert!(round.is_complete);
+    assert_eq!(round.total_contributed, 2_000_000);
+}
+
+#[test]
 fn test_member_groups() {
     let (env, admin, client, token) = setup_env();
 

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -37,6 +37,7 @@ pub struct RoundInfo {
     pub round_number: u32,
     pub recipient: Address,
     pub contributions: Map<Address, bool>,
+    pub contribution_amounts: Map<Address, i128>,
     pub total_contributed: i128,
     pub is_complete: bool,
     pub deadline: u64,


### PR DESCRIPTION
## Summary
- track cumulative per-member contribution amounts for each round
- add `contribute_partial` so members can pay toward the required amount in multiple transactions
- mark a member as complete only when cumulative progress reaches the group contribution amount
- add `get_member_contribution_progress` for frontend/progress queries
- keep existing full `contribute` behavior intact as a full-amount convenience path

Closes #48

## Verification
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`