### PR TITLE
Add completed group cloning

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -30,6 +30,7 @@ pub fn create_group(
 
     let group = SavingsGroup {
         id: group_id,
+        cloned_from: 0,
         name,
         admin: admin.clone(),
         token,
@@ -170,4 +171,49 @@ pub fn get_group(env: &Env, group_id: u64) -> Result<SavingsGroup, ContractError
 
 pub fn get_member_groups(env: &Env, member: Address) -> Vec<u64> {
     storage::get_member_groups(env, &member)
+}
+
+pub fn clone_group(env: &Env, admin: Address, source_group_id: u64) -> Result<u64, ContractError> {
+    admin.require_auth();
+    let source_group =
+        storage::get_group(env, source_group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if admin != source_group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+    if source_group.status != GroupStatus::Completed {
+        return Err(ContractError::GroupNotActive);
+    }
+
+    let group_id = storage::get_group_counter(env) + 1;
+    storage::set_group_counter(env, group_id);
+
+    let group = SavingsGroup {
+        id: group_id,
+        cloned_from: source_group.id,
+        name: source_group.name,
+        admin: admin.clone(),
+        token: source_group.token,
+        contribution_amount: source_group.contribution_amount,
+        cycle_length: source_group.cycle_length,
+        max_members: source_group.max_members,
+        members: source_group.members,
+        payout_order: Vec::new(env),
+        current_round: 0,
+        total_rounds: 0,
+        status: GroupStatus::Forming,
+        created_at: env.ledger().timestamp(),
+    };
+
+    storage::set_group(env, &group);
+    for member in group.members.iter() {
+        storage::add_member_group(env, &member, group_id);
+    }
+
+    env.events().publish(
+        (crate::symbol_short!("grp_clone"),),
+        (source_group_id, group_id),
+    );
+
+    Ok(group_id)
 }

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -74,6 +74,15 @@ impl SoroSaveContract {
         group::get_member_groups(&env, member)
     }
 
+    /// Clone a completed group into a new forming group with the same settings and members.
+    pub fn clone_group(
+        env: Env,
+        admin: Address,
+        source_group_id: u64,
+    ) -> Result<u64, ContractError> {
+        group::clone_group(&env, admin, source_group_id)
+    }
+
     // ─── Contributions ──────────────────────────────────────────────
 
     /// Contribute to the current round of a group.

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -46,6 +46,7 @@ fn test_create_group() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, admin);
+    assert_eq!(group.cloned_from, 0);
     assert_eq!(group.contribution_amount, 1_000_000);
     assert_eq!(group.max_members, 5);
     assert_eq!(group.status, GroupStatus::Forming);
@@ -149,6 +150,63 @@ fn test_full_cycle() {
     // Group should be completed
     let group = client.get_group(&group_id);
     assert_eq!(group.status, GroupStatus::Completed);
+}
+
+#[test]
+fn test_clone_completed_group() {
+    let (env, admin, client, _token) = setup_env();
+    let member1 = Address::generate(&env);
+
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin);
+    let token_sac = StellarAssetClient::new(&env, &token_id.address());
+    token_sac.mint(&admin, &10_000_000);
+    token_sac.mint(&member1, &10_000_000);
+
+    let source_group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Clone Source"),
+        &token_id.address(),
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    client.join_group(&member1, &source_group_id);
+    client.start_group(&admin, &source_group_id);
+
+    client.contribute(&admin, &source_group_id);
+    client.contribute(&member1, &source_group_id);
+    client.distribute_payout(&source_group_id);
+    client.contribute(&admin, &source_group_id);
+    client.contribute(&member1, &source_group_id);
+    client.distribute_payout(&source_group_id);
+
+    assert_eq!(
+        client.get_group(&source_group_id).status,
+        GroupStatus::Completed
+    );
+
+    let clone_id = client.clone_group(&admin, &source_group_id);
+    let cloned_group = client.get_group(&clone_id);
+    assert_eq!(cloned_group.cloned_from, source_group_id);
+    assert_eq!(cloned_group.admin, admin);
+    assert_eq!(cloned_group.token, token_id.address());
+    assert_eq!(cloned_group.contribution_amount, 1_000_000);
+    assert_eq!(cloned_group.cycle_length, 86400);
+    assert_eq!(cloned_group.max_members, 5);
+    assert_eq!(cloned_group.status, GroupStatus::Forming);
+    assert_eq!(cloned_group.members.len(), 2);
+    assert_eq!(cloned_group.current_round, 0);
+    assert_eq!(cloned_group.total_rounds, 0);
+    assert_eq!(cloned_group.payout_order.len(), 0);
+
+    let admin_groups = client.get_member_groups(&admin);
+    assert_eq!(admin_groups.len(), 2);
+    assert_eq!(admin_groups.get(1).unwrap(), clone_id);
+
+    let member_groups = client.get_member_groups(&member1);
+    assert_eq!(member_groups.len(), 2);
+    assert_eq!(member_groups.get(1).unwrap(), clone_id);
 }
 
 #[test]

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -16,6 +16,7 @@ pub enum GroupStatus {
 #[derive(Clone, Debug)]
 pub struct SavingsGroup {
     pub id: u64,
+    pub cloned_from: u64,
     pub name: String,
     pub admin: Address,
     pub token: Address,


### PR DESCRIPTION
## Summary
- add `cloned_from` metadata to savings groups
- add `clone_group(admin, source_group_id)` for completed source groups
- copy token, contribution amount, cycle length, max members, and previous members into a new forming group
- register the cloned group for each carried-over member
- cover clone metadata, copied settings, forming state, and member-group indexing in tests

Closes #70

## Verification
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`