### PR TITLE
Add multi-sig group admin support

### DIFF
--- a/contracts/sorosave/src/admin.rs
+++ b/contracts/sorosave/src/admin.rs
@@ -1,20 +1,21 @@
 use soroban_sdk::{Address, Env, String};
 
 use crate::errors::ContractError;
+use crate::multisig;
 use crate::storage;
-use crate::types::{Dispute, GroupStatus};
+use crate::types::{Dispute, GroupStatus, MultiSigAction};
 
 pub fn pause_group(env: &Env, admin: Address, group_id: u64) -> Result<(), ContractError> {
     admin.require_auth();
 
     let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
-    if admin != group.admin && admin != storage::get_admin(env) {
-        return Err(ContractError::Unauthorized);
-    }
-
     if group.status == GroupStatus::Completed {
         return Err(ContractError::GroupCompleted);
+    }
+
+    if !multisig::approve_sensitive_action(env, &group, admin, MultiSigAction::Pause)? {
+        return Ok(());
     }
 
     group.status = GroupStatus::Paused;
@@ -31,12 +32,12 @@ pub fn resume_group(env: &Env, admin: Address, group_id: u64) -> Result<(), Cont
 
     let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
-    if admin != group.admin && admin != storage::get_admin(env) {
-        return Err(ContractError::Unauthorized);
-    }
-
     if group.status != GroupStatus::Paused {
         return Err(ContractError::GroupNotActive);
+    }
+
+    if !multisig::approve_sensitive_action(env, &group, admin, MultiSigAction::Resume)? {
+        return Ok(());
     }
 
     group.status = GroupStatus::Active;
@@ -95,7 +96,7 @@ pub fn resolve_dispute(env: &Env, admin: Address, group_id: u64) -> Result<(), C
 
     let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
-    if admin != group.admin && admin != storage::get_admin(env) {
+    if !multisig::can_single_admin_act(env, &group, &admin) {
         return Err(ContractError::Unauthorized);
     }
 
@@ -118,13 +119,12 @@ pub fn emergency_withdraw(env: &Env, admin: Address, group_id: u64) -> Result<()
 
     let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
-    // Only protocol admin can trigger emergency withdraw
-    if admin != storage::get_admin(env) {
-        return Err(ContractError::Unauthorized);
-    }
-
     if group.status == GroupStatus::Completed {
         return Err(ContractError::GroupCompleted);
+    }
+
+    if !multisig::approve_sensitive_action(env, &group, admin, MultiSigAction::EmergencyWithdraw)? {
+        return Ok(());
     }
 
     // Calculate remaining balance and distribute equally
@@ -166,6 +166,16 @@ pub fn set_group_admin(
     }
 
     group.admin = new_admin.clone();
+    let mut has_new_admin = false;
+    for admin in group.admins.iter() {
+        if admin == new_admin {
+            has_new_admin = true;
+            break;
+        }
+    }
+    if !has_new_admin {
+        group.admins.push_back(new_admin.clone());
+    }
     storage::set_group(env, &group);
 
     env.events()

--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,6 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    InvalidThreshold = 19,
+    ProposalAlreadyApproved = 20,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -27,11 +27,15 @@ pub fn create_group(
 
     let mut members = Vec::new(env);
     members.push_back(admin.clone());
+    let mut admins = Vec::new(env);
+    admins.push_back(admin.clone());
 
     let group = SavingsGroup {
         id: group_id,
         name,
         admin: admin.clone(),
+        admins,
+        admin_threshold: 1,
         token,
         contribution_amount,
         cycle_length,

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -6,6 +6,7 @@ mod admin;
 mod contribution;
 mod errors;
 mod group;
+mod multisig;
 mod payout;
 mod storage;
 mod types;
@@ -162,6 +163,36 @@ impl SoroSaveContract {
         new_admin: Address,
     ) -> Result<(), ContractError> {
         admin::set_group_admin(&env, current_admin, group_id, new_admin)
+    }
+
+    /// Add another group admin.
+    pub fn add_admin(
+        env: Env,
+        current_admin: Address,
+        group_id: u64,
+        new_admin: Address,
+    ) -> Result<(), ContractError> {
+        multisig::add_admin(&env, current_admin, group_id, new_admin)
+    }
+
+    /// Remove a secondary group admin.
+    pub fn remove_admin(
+        env: Env,
+        current_admin: Address,
+        group_id: u64,
+        admin_to_remove: Address,
+    ) -> Result<(), ContractError> {
+        multisig::remove_admin(&env, current_admin, group_id, admin_to_remove)
+    }
+
+    /// Set the number of admin approvals required for sensitive group actions.
+    pub fn set_threshold(
+        env: Env,
+        current_admin: Address,
+        group_id: u64,
+        threshold: u32,
+    ) -> Result<(), ContractError> {
+        multisig::set_threshold(&env, current_admin, group_id, threshold)
     }
 }
 

--- a/contracts/sorosave/src/multisig.rs
+++ b/contracts/sorosave/src/multisig.rs
@@ -1,0 +1,185 @@
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::errors::ContractError;
+use crate::storage;
+use crate::types::{MultiSigAction, MultiSigProposal, SavingsGroup};
+
+pub fn is_group_admin(group: &SavingsGroup, admin: &Address) -> bool {
+    if *admin == group.admin {
+        return true;
+    }
+
+    for existing in group.admins.iter() {
+        if existing == *admin {
+            return true;
+        }
+    }
+
+    false
+}
+
+pub fn can_single_admin_act(env: &Env, group: &SavingsGroup, admin: &Address) -> bool {
+    is_group_admin(group, admin) || *admin == storage::get_admin(env)
+}
+
+pub fn ensure_group_admin(group: &SavingsGroup, admin: &Address) -> Result<(), ContractError> {
+    if !is_group_admin(group, admin) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    Ok(())
+}
+
+pub fn add_admin(
+    env: &Env,
+    current_admin: Address,
+    group_id: u64,
+    new_admin: Address,
+) -> Result<(), ContractError> {
+    current_admin.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if !can_single_admin_act(env, &group, &current_admin) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    for admin in group.admins.iter() {
+        if admin == new_admin {
+            return Err(ContractError::AlreadyMember);
+        }
+    }
+
+    group.admins.push_back(new_admin.clone());
+    storage::set_group(env, &group);
+
+    env.events()
+        .publish((crate::symbol_short!("adm_add"),), (group_id, new_admin));
+
+    Ok(())
+}
+
+pub fn remove_admin(
+    env: &Env,
+    current_admin: Address,
+    group_id: u64,
+    admin_to_remove: Address,
+) -> Result<(), ContractError> {
+    current_admin.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if !can_single_admin_act(env, &group, &current_admin) {
+        return Err(ContractError::Unauthorized);
+    }
+    if admin_to_remove == group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut found = false;
+    let mut admins = Vec::new(env);
+    for admin in group.admins.iter() {
+        if admin == admin_to_remove {
+            found = true;
+        } else {
+            admins.push_back(admin);
+        }
+    }
+
+    if !found {
+        return Err(ContractError::NotMember);
+    }
+    if group.admin_threshold > admins.len() {
+        return Err(ContractError::InvalidThreshold);
+    }
+    if group.admin_threshold > 1 && admins.len() < 2 {
+        return Err(ContractError::InvalidThreshold);
+    }
+
+    group.admins = admins;
+    storage::set_group(env, &group);
+
+    env.events().publish(
+        (crate::symbol_short!("adm_rem"),),
+        (group_id, admin_to_remove),
+    );
+
+    Ok(())
+}
+
+pub fn set_threshold(
+    env: &Env,
+    current_admin: Address,
+    group_id: u64,
+    threshold: u32,
+) -> Result<(), ContractError> {
+    current_admin.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if !can_single_admin_act(env, &group, &current_admin) {
+        return Err(ContractError::Unauthorized);
+    }
+    if threshold == 0 || threshold > group.admins.len() {
+        return Err(ContractError::InvalidThreshold);
+    }
+    if threshold > 1 && group.admins.len() < 2 {
+        return Err(ContractError::InvalidThreshold);
+    }
+
+    group.admin_threshold = threshold;
+    storage::set_group(env, &group);
+
+    env.events()
+        .publish((crate::symbol_short!("adm_thr"),), (group_id, threshold));
+
+    Ok(())
+}
+
+pub fn approve_sensitive_action(
+    env: &Env,
+    group: &SavingsGroup,
+    admin: Address,
+    action: MultiSigAction,
+) -> Result<bool, ContractError> {
+    if group.admin_threshold <= 1 {
+        if !can_single_admin_act(env, group, &admin) {
+            return Err(ContractError::Unauthorized);
+        }
+        return Ok(true);
+    }
+
+    ensure_group_admin(group, &admin)?;
+    if group.admins.len() < 2 || group.admin_threshold > group.admins.len() {
+        return Err(ContractError::InvalidThreshold);
+    }
+
+    let mut proposal =
+        storage::get_multisig_proposal(env, group.id, &action).unwrap_or(MultiSigProposal {
+            action: action.clone(),
+            approvals: Vec::new(env),
+            created_at: env.ledger().timestamp(),
+        });
+
+    for approver in proposal.approvals.iter() {
+        if approver == admin {
+            return Err(ContractError::ProposalAlreadyApproved);
+        }
+    }
+
+    proposal.approvals.push_back(admin.clone());
+
+    if proposal.approvals.len() >= group.admin_threshold {
+        storage::remove_multisig_proposal(env, group.id, &action);
+        env.events().publish(
+            (crate::symbol_short!("ms_exec"),),
+            (group.id, action, admin),
+        );
+        return Ok(true);
+    }
+
+    storage::set_multisig_proposal(env, group.id, &proposal);
+    env.events().publish(
+        (crate::symbol_short!("ms_appr"),),
+        (group.id, action, admin),
+    );
+
+    Ok(false)
+}

--- a/contracts/sorosave/src/storage.rs
+++ b/contracts/sorosave/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::types::{DataKey, Dispute, RoundInfo, SavingsGroup};
+use crate::types::{DataKey, Dispute, MultiSigAction, MultiSigProposal, RoundInfo, SavingsGroup};
 
 const INSTANCE_TTL_THRESHOLD: u32 = 100;
 const INSTANCE_TTL_EXTEND: u32 = 500;
@@ -119,6 +119,32 @@ pub fn set_dispute(env: &Env, group_id: u64, dispute: &Dispute) {
 
 pub fn remove_dispute(env: &Env, group_id: u64) {
     let key = DataKey::Dispute(group_id);
+    env.storage().persistent().remove(&key);
+}
+
+// --- Multi-Sig Proposals ---
+
+pub fn get_multisig_proposal(
+    env: &Env,
+    group_id: u64,
+    action: &MultiSigAction,
+) -> Option<MultiSigProposal> {
+    let key = DataKey::MultiSigProposal(group_id, action.clone());
+    let result = env.storage().persistent().get(&key);
+    if result.is_some() {
+        extend_persistent_ttl(env, &key);
+    }
+    result
+}
+
+pub fn set_multisig_proposal(env: &Env, group_id: u64, proposal: &MultiSigProposal) {
+    let key = DataKey::MultiSigProposal(group_id, proposal.action.clone());
+    env.storage().persistent().set(&key, proposal);
+    extend_persistent_ttl(env, &key);
+}
+
+pub fn remove_multisig_proposal(env: &Env, group_id: u64, action: &MultiSigAction) {
+    let key = DataKey::MultiSigProposal(group_id, action.clone());
     env.storage().persistent().remove(&key);
 }
 

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -50,6 +50,9 @@ fn test_create_group() {
     assert_eq!(group.max_members, 5);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
+    assert_eq!(group.admins.len(), 1);
+    assert_eq!(group.admins.get(0).unwrap(), admin);
+    assert_eq!(group.admin_threshold, 1);
 }
 
 #[test]
@@ -221,4 +224,79 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+    assert_eq!(group.admins.len(), 2);
+    assert_eq!(group.admins.get(1).unwrap(), new_admin);
+}
+
+#[test]
+fn test_multisig_pause_requires_threshold() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+
+    let member1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.add_admin(&admin, &group_id, &admin2);
+    client.set_threshold(&admin, &group_id, &2);
+    client.start_group(&admin, &group_id);
+
+    client.pause_group(&admin, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Active);
+
+    client.pause_group(&admin2, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Paused);
+}
+
+#[test]
+fn test_multisig_resume_requires_threshold() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+
+    let member1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.add_admin(&admin, &group_id, &admin2);
+    client.set_threshold(&admin, &group_id, &2);
+    client.start_group(&admin, &group_id);
+    client.pause_group(&admin, &group_id);
+    client.pause_group(&admin2, &group_id);
+
+    client.resume_group(&admin, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Paused);
+
+    client.resume_group(&admin2, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Active);
+}
+
+#[test]
+fn test_multisig_admin_management_validates_threshold() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    let admin2 = Address::generate(&env);
+
+    client.add_admin(&admin, &group_id, &admin2);
+    client.set_threshold(&admin, &group_id, &2);
+
+    let group = client.get_group(&group_id);
+    assert_eq!(group.admins.len(), 2);
+    assert_eq!(group.admin_threshold, 2);
+}
+
+#[test]
+fn test_multisig_emergency_withdraw_requires_threshold() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+
+    let member1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.add_admin(&admin, &group_id, &admin2);
+    client.set_threshold(&admin, &group_id, &2);
+    client.start_group(&admin, &group_id);
+
+    client.emergency_withdraw(&admin, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Active);
+
+    client.emergency_withdraw(&admin2, &group_id);
+    assert_eq!(client.get_group(&group_id).status, GroupStatus::Completed);
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -18,6 +18,8 @@ pub struct SavingsGroup {
     pub id: u64,
     pub name: String,
     pub admin: Address,
+    pub admins: Vec<Address>,
+    pub admin_threshold: u32,
     pub token: Address,
     pub contribution_amount: i128,
     pub cycle_length: u64,
@@ -51,6 +53,24 @@ pub struct Dispute {
     pub raised_at: u64,
 }
 
+/// Sensitive group action that requires multi-admin approval when enabled.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum MultiSigAction {
+    Pause,
+    Resume,
+    EmergencyWithdraw,
+}
+
+/// Pending approval state for a sensitive multi-admin action.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MultiSigProposal {
+    pub action: MultiSigAction,
+    pub approvals: Vec<Address>,
+    pub created_at: u64,
+}
+
 /// Storage keys for all contract data.
 #[contracttype]
 #[derive(Clone)]
@@ -61,4 +81,5 @@ pub enum DataKey {
     Round(u64, u32),
     MemberGroups(Address),
     Dispute(u64),
+    MultiSigProposal(u64, MultiSigAction),
 }


### PR DESCRIPTION
## Summary

Implements multi-admin governance for savings groups to address #59.

- Adds `admins` and `admin_threshold` to `SavingsGroup`, initialized with the creator and threshold `1` for backward compatibility.
- Adds `add_admin`, `remove_admin`, and `set_threshold` contract methods with threshold validation.
- Adds stored multi-sig proposals for sensitive group actions: pause, resume, and emergency withdraw.
- Keeps existing single-admin behavior when threshold is `1`, and requires M-of-N group-admin approvals when threshold is greater than `1`.
- Adds tests for threshold-gated pause, resume, emergency withdraw, and admin threshold setup.

## Verification

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Closes #59