### PR TITLE
Add randomized payout order option

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -1,24 +1,20 @@
-use soroban_sdk::{Address, Env, Map, String, Vec};
+use soroban_sdk::{Address, Env, Map, Vec};
 
 use crate::errors::ContractError;
 use crate::storage;
-use crate::types::{GroupStatus, RoundInfo, SavingsGroup};
+use crate::types::{CreateGroupConfig, GroupStatus, RoundInfo, SavingsGroup};
 
 pub fn create_group(
     env: &Env,
     admin: Address,
-    name: String,
-    token: Address,
-    contribution_amount: i128,
-    cycle_length: u64,
-    max_members: u32,
+    config: CreateGroupConfig,
 ) -> Result<u64, ContractError> {
     admin.require_auth();
 
-    if contribution_amount <= 0 {
+    if config.contribution_amount <= 0 {
         return Err(ContractError::InvalidAmount);
     }
-    if max_members < 2 {
+    if config.max_members < 2 {
         return Err(ContractError::InsufficientMembers);
     }
 
@@ -30,12 +26,13 @@ pub fn create_group(
 
     let group = SavingsGroup {
         id: group_id,
-        name,
+        name: config.name,
         admin: admin.clone(),
-        token,
-        contribution_amount,
-        cycle_length,
-        max_members,
+        token: config.token,
+        contribution_amount: config.contribution_amount,
+        cycle_length: config.cycle_length,
+        max_members: config.max_members,
+        randomize_order: config.randomize_order,
         members,
         payout_order: Vec::new(env),
         current_round: 0,
@@ -138,8 +135,11 @@ pub fn start_group(env: &Env, admin: Address, group_id: u64) -> Result<(), Contr
         return Err(ContractError::InsufficientMembers);
     }
 
-    // Set payout order to member join order (can be randomized later)
-    group.payout_order = group.members.clone();
+    group.payout_order = if group.randomize_order {
+        deterministic_shuffle(env, group_id, &group.members)
+    } else {
+        group.members.clone()
+    };
     group.total_rounds = group.members.len();
     group.current_round = 1;
     group.status = GroupStatus::Active;
@@ -170,4 +170,56 @@ pub fn get_group(env: &Env, group_id: u64) -> Result<SavingsGroup, ContractError
 
 pub fn get_member_groups(env: &Env, member: Address) -> Vec<u64> {
     storage::get_member_groups(env, &member)
+}
+
+fn deterministic_shuffle(env: &Env, group_id: u64, members: &Vec<Address>) -> Vec<Address> {
+    let mut remaining = members.clone();
+    let mut shuffled = Vec::new(env);
+    let mut seed = env.ledger().timestamp() ^ ((env.ledger().sequence() as u64) << 32) ^ group_id;
+
+    while !remaining.is_empty() {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let index = (seed % remaining.len() as u64) as u32;
+        shuffled.push_back(remaining.get(index).unwrap());
+
+        let mut next_remaining = Vec::new(env);
+        for i in 0..remaining.len() {
+            if i != index {
+                next_remaining.push_back(remaining.get(i).unwrap());
+            }
+        }
+        remaining = next_remaining;
+    }
+
+    if members.len() > 1 && has_same_order(members, &shuffled) {
+        reverse_order(env, members)
+    } else {
+        shuffled
+    }
+}
+
+fn has_same_order(left: &Vec<Address>, right: &Vec<Address>) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+
+    for i in 0..left.len() {
+        if left.get(i).unwrap() != right.get(i).unwrap() {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn reverse_order(env: &Env, members: &Vec<Address>) -> Vec<Address> {
+    let mut reversed = Vec::new(env);
+    let mut index = members.len();
+
+    while index > 0 {
+        index -= 1;
+        reversed.push_back(members.get(index).unwrap());
+    }
+
+    reversed
 }

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -32,21 +32,9 @@ impl SoroSaveContract {
     pub fn create_group(
         env: Env,
         admin: Address,
-        name: String,
-        token: Address,
-        contribution_amount: i128,
-        cycle_length: u64,
-        max_members: u32,
+        config: CreateGroupConfig,
     ) -> Result<u64, ContractError> {
-        group::create_group(
-            &env,
-            admin,
-            name,
-            token,
-            contribution_amount,
-            cycle_length,
-            max_members,
-        )
+        group::create_group(&env, admin, config)
     }
 
     /// Join an existing group that is still forming.

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -1,6 +1,10 @@
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env, String,
+};
 
-use crate::types::GroupStatus;
+use crate::types::{CreateGroupConfig, GroupStatus};
 use crate::{SoroSaveContract, SoroSaveContractClient};
 
 fn setup_env() -> (Env, Address, SoroSaveContractClient<'static>, Address) {
@@ -28,14 +32,18 @@ fn create_test_group(
     admin: &Address,
     token: &Address,
 ) -> u64 {
-    client.create_group(
-        admin,
-        &String::from_str(env, "Test Savings Group"),
-        token,
-        &1_000_000, // 1 token (7 decimals)
-        &86400,     // 1 day cycle
-        &5,         // max 5 members
-    )
+    client.create_group(admin, &create_group_config(env, token, false))
+}
+
+fn create_group_config(env: &Env, token: &Address, randomize_order: bool) -> CreateGroupConfig {
+    CreateGroupConfig {
+        name: String::from_str(env, "Test Savings Group"),
+        token: token.clone(),
+        contribution_amount: 1_000_000, // 1 token (7 decimals)
+        cycle_length: 86400,            // 1 day cycle
+        max_members: 5,                 // max 5 members
+        randomize_order,
+    }
 }
 
 #[test]
@@ -48,6 +56,7 @@ fn test_create_group() {
     assert_eq!(group.admin, admin);
     assert_eq!(group.contribution_amount, 1_000_000);
     assert_eq!(group.max_members, 5);
+    assert!(!group.randomize_order);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
 }
@@ -118,11 +127,14 @@ fn test_full_cycle() {
     // Create a new group with the token we control
     let group_id = client.create_group(
         &admin,
-        &String::from_str(&env, "Full Cycle Test"),
-        &token_id.address(),
-        &1_000_000,
-        &86400,
-        &5,
+        &CreateGroupConfig {
+            name: String::from_str(&env, "Full Cycle Test"),
+            token: token_id.address(),
+            contribution_amount: 1_000_000,
+            cycle_length: 86400,
+            max_members: 5,
+            randomize_order: false,
+        },
     );
     client.join_group(&member1, &group_id);
     client.start_group(&admin, &group_id);
@@ -158,11 +170,14 @@ fn test_member_groups() {
     let group1 = create_test_group(&env, &client, &admin, &token);
     let group2 = client.create_group(
         &admin,
-        &String::from_str(&env, "Second Group"),
-        &token,
-        &500_000,
-        &43200,
-        &3,
+        &CreateGroupConfig {
+            name: String::from_str(&env, "Second Group"),
+            token: token.clone(),
+            contribution_amount: 500_000,
+            cycle_length: 43200,
+            max_members: 3,
+            randomize_order: false,
+        },
     );
 
     let groups = client.get_member_groups(&admin);
@@ -221,4 +236,37 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+}
+
+#[test]
+fn test_randomized_payout_order_uses_deterministic_shuffle() {
+    let (env, admin, client, token) = setup_env();
+    env.ledger().set_timestamp(123_456);
+    env.ledger().set_sequence_number(42);
+
+    let group_id = client.create_group(&admin, &create_group_config(&env, &token, true));
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let member3 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.join_group(&member3, &group_id);
+    client.start_group(&admin, &group_id);
+
+    let group = client.get_group(&group_id);
+    assert!(group.randomize_order);
+    assert_eq!(group.payout_order.len(), group.members.len());
+    assert_ne!(group.payout_order, group.members);
+
+    for member in group.members.iter() {
+        let mut found = false;
+        for payout_member in group.payout_order.iter() {
+            if payout_member == member {
+                found = true;
+                break;
+            }
+        }
+        assert!(found);
+    }
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -11,6 +11,18 @@ pub enum GroupStatus {
     Paused,    // Admin has paused the group
 }
 
+/// Group creation parameters.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CreateGroupConfig {
+    pub name: String,
+    pub token: Address,
+    pub contribution_amount: i128,
+    pub cycle_length: u64,
+    pub max_members: u32,
+    pub randomize_order: bool,
+}
+
 /// Core savings group configuration and state.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -22,6 +34,7 @@ pub struct SavingsGroup {
     pub contribution_amount: i128,
     pub cycle_length: u64,
     pub max_members: u32,
+    pub randomize_order: bool,
     pub members: Vec<Address>,
     pub payout_order: Vec<Address>,
     pub current_round: u32,


### PR DESCRIPTION
## Summary

Implements randomized payout order support for #1.

- Adds `CreateGroupConfig` with an explicit `randomize_order` flag so the creation API stays under the existing clippy argument-count gate.
- Stores `randomize_order` on each `SavingsGroup`.
- Uses a deterministic ledger-derived shuffle when a randomized group starts.
- Preserves join-order payout behavior for groups with `randomize_order = false`.
- Adds a test proving randomized groups keep the same members while changing payout order deterministically.

## Verification

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Closes #1