### PR TITLE
Track contribution defaults after deadlines

### DIFF
--- a/contracts/sorosave/src/contribution.rs
+++ b/contracts/sorosave/src/contribution.rs
@@ -31,6 +31,11 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
     if round_info.is_complete {
         return Err(ContractError::RoundNotActive);
     }
+    if env.ledger().timestamp() > round_info.deadline {
+        mark_defaults_for_round(env, group_id, &group, &mut round_info);
+        storage::set_round(env, group_id, &round_info);
+        return Err(ContractError::RoundNotActive);
+    }
 
     // Check if already contributed this round
     if round_info.contributions.contains_key(member.clone()) {
@@ -64,6 +69,29 @@ pub fn contribute(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
     Ok(())
 }
 
+pub fn mark_defaults(env: &Env, group_id: u64) -> Result<(), ContractError> {
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if group.status != GroupStatus::Active {
+        return Err(ContractError::GroupNotActive);
+    }
+
+    let mut round_info = storage::get_round(env, group_id, group.current_round)
+        .ok_or(ContractError::RoundNotActive)?;
+
+    if round_info.is_complete {
+        return Err(ContractError::RoundNotActive);
+    }
+    if env.ledger().timestamp() <= round_info.deadline {
+        return Err(ContractError::RoundNotActive);
+    }
+
+    mark_defaults_for_round(env, group_id, &group, &mut round_info);
+    storage::set_round(env, group_id, &round_info);
+
+    Ok(())
+}
+
 pub fn get_round_status(env: &Env, group_id: u64, round: u32) -> Result<RoundInfo, ContractError> {
     storage::get_round(env, group_id, round).ok_or(ContractError::RoundNotActive)
 }
@@ -77,4 +105,34 @@ pub fn has_contributed(
     let round_info =
         storage::get_round(env, group_id, round).ok_or(ContractError::RoundNotActive)?;
     Ok(round_info.contributions.contains_key(member))
+}
+
+fn mark_defaults_for_round(
+    env: &Env,
+    group_id: u64,
+    group: &crate::types::SavingsGroup,
+    round_info: &mut RoundInfo,
+) {
+    for member in group.members.iter() {
+        if round_info.contributions.contains_key(member.clone()) {
+            continue;
+        }
+        if has_defaulted(round_info, &member) {
+            continue;
+        }
+
+        round_info.defaulted_members.push_back(member.clone());
+        env.events()
+            .publish((crate::symbol_short!("default"),), (group_id, member));
+    }
+}
+
+fn has_defaulted(round_info: &RoundInfo, member: &Address) -> bool {
+    for defaulted in round_info.defaulted_members.iter() {
+        if defaulted == *member {
+            return true;
+        }
+    }
+
+    false
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -150,6 +150,7 @@ pub fn start_group(env: &Env, admin: Address, group_id: u64) -> Result<(), Contr
         round_number: 1,
         recipient: first_recipient,
         contributions: Map::new(env),
+        defaulted_members: Vec::new(env),
         total_contributed: 0,
         is_complete: false,
         deadline: env.ledger().timestamp() + group.cycle_length,

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -100,6 +100,11 @@ impl SoroSaveContract {
         contribution::has_contributed(&env, member, group_id, round)
     }
 
+    /// Mark current-round members as defaulted after the contribution deadline.
+    pub fn mark_defaults(env: Env, group_id: u64) -> Result<(), ContractError> {
+        contribution::mark_defaults(&env, group_id)
+    }
+
     // ─── Payouts ────────────────────────────────────────────────────
 
     /// Distribute the pot to the current round's recipient. Anyone can call this

--- a/contracts/sorosave/src/payout.rs
+++ b/contracts/sorosave/src/payout.rs
@@ -50,6 +50,7 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
             round_number: group.current_round,
             recipient: next_recipient,
             contributions: Map::new(env),
+            defaulted_members: Vec::new(env),
             total_contributed: 0,
             is_complete: false,
             deadline: env.ledger().timestamp() + group.cycle_length,

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -1,4 +1,8 @@
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env, String,
+};
 
 use crate::types::GroupStatus;
 use crate::{SoroSaveContract, SoroSaveContractClient};
@@ -96,6 +100,13 @@ fn test_start_group() {
     assert_eq!(group.current_round, 1);
     assert_eq!(group.total_rounds, 2);
     assert_eq!(group.payout_order.len(), 2);
+    assert_eq!(
+        client
+            .get_round_status(&group_id, &1)
+            .defaulted_members
+            .len(),
+        0
+    );
 }
 
 #[test]
@@ -221,4 +232,28 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+}
+
+#[test]
+fn test_mark_defaults_after_deadline() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.start_group(&admin, &group_id);
+
+    client.contribute(&admin, &group_id);
+
+    let round = client.get_round_status(&group_id, &1);
+    env.ledger().set_timestamp(round.deadline + 1);
+
+    client.mark_defaults(&group_id);
+
+    let round = client.get_round_status(&group_id, &1);
+    assert_eq!(round.defaulted_members.len(), 2);
+    assert_eq!(round.defaulted_members.get(0).unwrap(), member1);
+    assert_eq!(round.defaulted_members.get(1).unwrap(), member2);
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -37,6 +37,7 @@ pub struct RoundInfo {
     pub round_number: u32,
     pub recipient: Address,
     pub contributions: Map<Address, bool>,
+    pub defaulted_members: Vec<Address>,
     pub total_contributed: i128,
     pub is_complete: bool,
     pub deadline: u64,


### PR DESCRIPTION
## Summary

Implements contribution deadline default tracking for #2.

- Adds `defaulted_members` to each round.
- Rejects late contributions after the current round deadline.
- Adds `mark_defaults` so anyone can record current-round non-contributors after the deadline.
- Emits a default event for each newly marked defaulted member.
- Adds a deadline/default tracking test.

## Verification

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Closes #2