### PR TITLE
Add missed contribution penalties

### DIFF
--- a/contracts/sorosave/src/contribution.rs
+++ b/contracts/sorosave/src/contribution.rs
@@ -78,3 +78,87 @@ pub fn has_contributed(
         storage::get_round(env, group_id, round).ok_or(ContractError::RoundNotActive)?;
     Ok(round_info.contributions.contains_key(member))
 }
+
+pub fn set_penalty_rate(
+    env: &Env,
+    admin: Address,
+    group_id: u64,
+    penalty_rate_bps: u32,
+) -> Result<(), ContractError> {
+    admin.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if admin != group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+    if penalty_rate_bps > 10_000 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    group.penalty_rate_bps = penalty_rate_bps;
+    storage::set_group(env, &group);
+
+    env.events().publish(
+        (crate::symbol_short!("pen_rate"),),
+        (group_id, penalty_rate_bps),
+    );
+
+    Ok(())
+}
+
+pub fn apply_missed_penalty(
+    env: &Env,
+    admin: Address,
+    group_id: u64,
+    member: Address,
+) -> Result<i128, ContractError> {
+    admin.require_auth();
+
+    let group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if admin != group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+    if group.status != GroupStatus::Active {
+        return Err(ContractError::GroupNotActive);
+    }
+    if group.penalty_rate_bps == 0 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    let round_info = storage::get_round(env, group_id, group.current_round)
+        .ok_or(ContractError::RoundNotActive)?;
+    if env.ledger().timestamp() <= round_info.deadline {
+        return Err(ContractError::RoundNotActive);
+    }
+    if round_info.contributions.contains_key(member.clone()) {
+        return Err(ContractError::AlreadyContributed);
+    }
+    if !is_group_member(&group.members, &member) {
+        return Err(ContractError::NotMember);
+    }
+
+    let penalty = group.contribution_amount * group.penalty_rate_bps as i128 / 10_000;
+    let current_penalty = storage::get_member_penalty(env, group_id, &member);
+    storage::set_member_penalty(env, group_id, &member, current_penalty + penalty);
+
+    env.events().publish(
+        (crate::symbol_short!("penalty"),),
+        (group_id, member, penalty),
+    );
+
+    Ok(penalty)
+}
+
+pub fn get_member_penalty(env: &Env, group_id: u64, member: Address) -> i128 {
+    storage::get_member_penalty(env, group_id, &member)
+}
+
+fn is_group_member(members: &soroban_sdk::Vec<Address>, member: &Address) -> bool {
+    for current in members.iter() {
+        if current == *member {
+            return true;
+        }
+    }
+
+    false
+}

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -36,6 +36,7 @@ pub fn create_group(
         contribution_amount,
         cycle_length,
         max_members,
+        penalty_rate_bps: 0,
         members,
         payout_order: Vec::new(env),
         current_round: 0,

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -100,6 +100,31 @@ impl SoroSaveContract {
         contribution::has_contributed(&env, member, group_id, round)
     }
 
+    /// Configure the penalty rate in basis points for missed contributions.
+    pub fn set_penalty_rate(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        penalty_rate_bps: u32,
+    ) -> Result<(), ContractError> {
+        contribution::set_penalty_rate(&env, admin, group_id, penalty_rate_bps)
+    }
+
+    /// Apply a penalty to a member who missed the current round deadline.
+    pub fn apply_missed_penalty(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        member: Address,
+    ) -> Result<i128, ContractError> {
+        contribution::apply_missed_penalty(&env, admin, group_id, member)
+    }
+
+    /// Read the stored penalty balance for a group member.
+    pub fn get_member_penalty(env: Env, group_id: u64, member: Address) -> i128 {
+        contribution::get_member_penalty(&env, group_id, member)
+    }
+
     // ─── Payouts ────────────────────────────────────────────────────
 
     /// Distribute the pot to the current round's recipient. Anyone can call this

--- a/contracts/sorosave/src/payout.rs
+++ b/contracts/sorosave/src/payout.rs
@@ -18,21 +18,31 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
         return Err(ContractError::RoundNotComplete);
     }
 
+    let penalty = storage::get_member_penalty(env, group_id, &round_info.recipient);
+    let payout_amount = if penalty >= round_info.total_contributed {
+        0
+    } else {
+        round_info.total_contributed - penalty
+    };
+
+    if penalty > 0 {
+        let remaining_penalty = penalty - (round_info.total_contributed - payout_amount);
+        storage::set_member_penalty(env, group_id, &round_info.recipient, remaining_penalty);
+    }
+
     // Transfer the pot to the round's recipient
     let token_client = soroban_sdk::token::Client::new(env, &group.token);
-    token_client.transfer(
-        &env.current_contract_address(),
-        &round_info.recipient,
-        &round_info.total_contributed,
-    );
+    if payout_amount > 0 {
+        token_client.transfer(
+            &env.current_contract_address(),
+            &round_info.recipient,
+            &payout_amount,
+        );
+    }
 
     env.events().publish(
         (crate::symbol_short!("payout"),),
-        (
-            group_id,
-            round_info.recipient.clone(),
-            round_info.total_contributed,
-        ),
+        (group_id, round_info.recipient.clone(), payout_amount),
     );
 
     // Advance to next round or complete the group

--- a/contracts/sorosave/src/storage.rs
+++ b/contracts/sorosave/src/storage.rs
@@ -122,6 +122,27 @@ pub fn remove_dispute(env: &Env, group_id: u64) {
     env.storage().persistent().remove(&key);
 }
 
+// --- Member Penalties ---
+
+pub fn get_member_penalty(env: &Env, group_id: u64, member: &Address) -> i128 {
+    let key = DataKey::MemberPenalty(group_id, member.clone());
+    let result: Option<i128> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        extend_persistent_ttl(env, &key);
+    }
+    result.unwrap_or(0)
+}
+
+pub fn set_member_penalty(env: &Env, group_id: u64, member: &Address, amount: i128) {
+    let key = DataKey::MemberPenalty(group_id, member.clone());
+    if amount <= 0 {
+        env.storage().persistent().remove(&key);
+    } else {
+        env.storage().persistent().set(&key, &amount);
+        extend_persistent_ttl(env, &key);
+    }
+}
+
 // --- TTL Management ---
 
 fn extend_instance_ttl(env: &Env) {

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -1,4 +1,8 @@
-use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env, String,
+};
 
 use crate::types::GroupStatus;
 use crate::{SoroSaveContract, SoroSaveContractClient};
@@ -48,6 +52,7 @@ fn test_create_group() {
     assert_eq!(group.admin, admin);
     assert_eq!(group.contribution_amount, 1_000_000);
     assert_eq!(group.max_members, 5);
+    assert_eq!(group.penalty_rate_bps, 0);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
 }
@@ -221,4 +226,50 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+}
+
+#[test]
+fn test_missed_contribution_penalty_reduces_future_payout() {
+    let (env, admin, client, _token) = setup_env();
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin.clone());
+    let token = token_id.address();
+    let token_sac = StellarAssetClient::new(&env, &token);
+
+    let member1 = Address::generate(&env);
+    token_sac.mint(&admin, &10_000_000);
+    token_sac.mint(&member1, &10_000_000);
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Penalty Test"),
+        &token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    client.join_group(&member1, &group_id);
+    client.set_penalty_rate(&admin, &group_id, &1_000);
+    client.start_group(&admin, &group_id);
+
+    let round = client.get_round_status(&group_id, &1);
+    env.ledger().set_timestamp(round.deadline + 1);
+
+    let penalty = client.apply_missed_penalty(&admin, &group_id, &member1);
+    assert_eq!(penalty, 100_000);
+    assert_eq!(client.get_member_penalty(&group_id, &member1), 100_000);
+
+    client.contribute(&admin, &group_id);
+    client.contribute(&member1, &group_id);
+    client.distribute_payout(&group_id);
+
+    client.contribute(&admin, &group_id);
+    client.contribute(&member1, &group_id);
+
+    let member_balance_before = soroban_sdk::token::Client::new(&env, &token).balance(&member1);
+    client.distribute_payout(&group_id);
+    let member_balance_after = soroban_sdk::token::Client::new(&env, &token).balance(&member1);
+
+    assert_eq!(member_balance_after - member_balance_before, 1_900_000);
+    assert_eq!(client.get_member_penalty(&group_id, &member1), 0);
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -22,6 +22,7 @@ pub struct SavingsGroup {
     pub contribution_amount: i128,
     pub cycle_length: u64,
     pub max_members: u32,
+    pub penalty_rate_bps: u32,
     pub members: Vec<Address>,
     pub payout_order: Vec<Address>,
     pub current_round: u32,
@@ -61,4 +62,5 @@ pub enum DataKey {
     Round(u64, u32),
     MemberGroups(Address),
     Dispute(u64),
+    MemberPenalty(u64, Address),
 }


### PR DESCRIPTION
## Summary

Implements missed-contribution penalties for #3.

- Adds `penalty_rate_bps` to group state.
- Adds admin `set_penalty_rate` configuration.
- Tracks per-member penalty balances in persistent storage.
- Adds `apply_missed_penalty` for missed current-round contributions after the deadline.
- Deducts stored penalties from a defaulter's future payout and clears the consumed penalty balance.
- Adds a payout test proving the future payout reduction.

## Verification

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Closes #3