### PR TITLE
Add invite-only group joins

### DIFF
--- a/contracts/sorosave/src/errors.rs
+++ b/contracts/sorosave/src/errors.rs
@@ -22,4 +22,5 @@ pub enum ContractError {
     InsufficientMembers = 16,
     RoundNotComplete = 17,
     GroupCompleted = 18,
+    InvalidInvite = 19,
 }

--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -36,6 +36,8 @@ pub fn create_group(
         contribution_amount,
         cycle_length,
         max_members,
+        invite_required: false,
+        invite_code_hash: 0,
         members,
         payout_order: Vec::new(env),
         current_round: 0,
@@ -58,6 +60,64 @@ pub fn join_group(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
 
     let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
 
+    if group.invite_required {
+        return Err(ContractError::InvalidInvite);
+    }
+
+    join_group_inner(env, member, &mut group)
+}
+
+pub fn join_group_with_invite(
+    env: &Env,
+    member: Address,
+    group_id: u64,
+    invite_code: u64,
+) -> Result<(), ContractError> {
+    member.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if !group.invite_required || hash_invite_code(invite_code) != group.invite_code_hash {
+        return Err(ContractError::InvalidInvite);
+    }
+
+    join_group_inner(env, member, &mut group)
+}
+
+pub fn enable_invites(
+    env: &Env,
+    admin: Address,
+    group_id: u64,
+    invite_code: u64,
+) -> Result<u64, ContractError> {
+    admin.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if admin != group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+    if group.status != GroupStatus::Forming {
+        return Err(ContractError::GroupNotForming);
+    }
+
+    let invite_code_hash = hash_invite_code(invite_code);
+    group.invite_required = true;
+    group.invite_code_hash = invite_code_hash;
+    storage::set_group(env, &group);
+
+    env.events().publish(
+        (crate::symbol_short!("invite"),),
+        (group_id, invite_code_hash),
+    );
+
+    Ok(invite_code_hash)
+}
+
+fn join_group_inner(
+    env: &Env,
+    member: Address,
+    group: &mut SavingsGroup,
+) -> Result<(), ContractError> {
     if group.status != GroupStatus::Forming {
         return Err(ContractError::GroupNotForming);
     }
@@ -74,13 +134,20 @@ pub fn join_group(env: &Env, member: Address, group_id: u64) -> Result<(), Contr
     }
 
     group.members.push_back(member.clone());
-    storage::set_group(env, &group);
-    storage::add_member_group(env, &member, group_id);
+    storage::set_group(env, group);
+    storage::add_member_group(env, &member, group.id);
 
     env.events()
-        .publish((crate::symbol_short!("grp_join"),), (group_id, member));
+        .publish((crate::symbol_short!("grp_join"),), (group.id, member));
 
     Ok(())
+}
+
+fn hash_invite_code(invite_code: u64) -> u64 {
+    invite_code
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .rotate_left(17)
+        ^ 0xBF58_476D_1CE4_E5B9
 }
 
 pub fn leave_group(env: &Env, member: Address, group_id: u64) -> Result<(), ContractError> {

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -54,6 +54,26 @@ impl SoroSaveContract {
         group::join_group(&env, member, group_id)
     }
 
+    /// Enable invite-only joining for a forming group.
+    pub fn enable_invites(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        invite_code: u64,
+    ) -> Result<u64, ContractError> {
+        group::enable_invites(&env, admin, group_id, invite_code)
+    }
+
+    /// Join an invite-only group using its raw invite code.
+    pub fn join_group_with_invite(
+        env: Env,
+        member: Address,
+        group_id: u64,
+        invite_code: u64,
+    ) -> Result<(), ContractError> {
+        group::join_group_with_invite(&env, member, group_id, invite_code)
+    }
+
     /// Leave a group (only allowed while group is still forming).
     pub fn leave_group(env: Env, member: Address, group_id: u64) -> Result<(), ContractError> {
         group::leave_group(&env, member, group_id)

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -48,6 +48,8 @@ fn test_create_group() {
     assert_eq!(group.admin, admin);
     assert_eq!(group.contribution_amount, 1_000_000);
     assert_eq!(group.max_members, 5);
+    assert!(!group.invite_required);
+    assert_eq!(group.invite_code_hash, 0);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
 }
@@ -221,4 +223,26 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+}
+
+#[test]
+fn test_invite_required_group_join() {
+    let (env, admin, client, token) = setup_env();
+    let group_id = create_test_group(&env, &client, &admin, &token);
+    let member1 = Address::generate(&env);
+    let invite_hash = client.enable_invites(&admin, &group_id, &123_456);
+
+    let group = client.get_group(&group_id);
+    assert!(group.invite_required);
+    assert_eq!(group.invite_code_hash, invite_hash);
+
+    let wrong_code_result = client.try_join_group_with_invite(&member1, &group_id, &999_999);
+    assert!(wrong_code_result.is_err());
+
+    client.join_group_with_invite(&member1, &group_id, &123_456);
+    assert_eq!(client.get_group(&group_id).members.len(), 2);
+
+    let member2 = Address::generate(&env);
+    let direct_join_result = client.try_join_group(&member2, &group_id);
+    assert!(direct_join_result.is_err());
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -22,6 +22,8 @@ pub struct SavingsGroup {
     pub contribution_amount: i128,
     pub cycle_length: u64,
     pub max_members: u32,
+    pub invite_required: bool,
+    pub invite_code_hash: u64,
     pub members: Vec<Address>,
     pub payout_order: Vec<Address>,
     pub current_round: u32,


### PR DESCRIPTION
## Summary

Implements invite-only group joins for #6.

- Adds `invite_required` and `invite_code_hash` to group state.
- Adds admin `enable_invites` for forming groups.
- Stores a deterministic hash of the invite code rather than the raw code.
- Blocks direct `join_group` for invite-only groups.
- Adds `join_group_with_invite` and validation tests for wrong and correct invite codes.

## Verification

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Closes #6