### PR TITLE
Add early payout requests

### DIFF
--- a/contracts/sorosave/src/group.rs
+++ b/contracts/sorosave/src/group.rs
@@ -36,6 +36,7 @@ pub fn create_group(
         contribution_amount,
         cycle_length,
         max_members,
+        early_payout_threshold_bps: 10_000,
         members,
         payout_order: Vec::new(env),
         current_round: 0,

--- a/contracts/sorosave/src/lib.rs
+++ b/contracts/sorosave/src/lib.rs
@@ -108,6 +108,25 @@ impl SoroSaveContract {
         payout::distribute_payout(&env, group_id)
     }
 
+    /// Request an early payout once the configured threshold has been contributed.
+    pub fn request_early_payout(
+        env: Env,
+        recipient: Address,
+        group_id: u64,
+    ) -> Result<(), ContractError> {
+        payout::request_early_payout(&env, recipient, group_id)
+    }
+
+    /// Configure early-payout threshold in basis points.
+    pub fn set_early_payout_threshold(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        threshold_bps: u32,
+    ) -> Result<(), ContractError> {
+        payout::set_early_payout_threshold(&env, admin, group_id, threshold_bps)
+    }
+
     /// Get the payout order for a group.
     pub fn get_payout_order(env: Env, group_id: u64) -> Result<Vec<Address>, ContractError> {
         payout::get_payout_order(&env, group_id)

--- a/contracts/sorosave/src/payout.rs
+++ b/contracts/sorosave/src/payout.rs
@@ -35,10 +35,91 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
         ),
     );
 
+    advance_round(env, group_id, &mut group)
+}
+
+pub fn request_early_payout(
+    env: &Env,
+    recipient: Address,
+    group_id: u64,
+) -> Result<(), ContractError> {
+    recipient.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+
+    if group.status != GroupStatus::Active {
+        return Err(ContractError::GroupNotActive);
+    }
+
+    let round_info = storage::get_round(env, group_id, group.current_round)
+        .ok_or(ContractError::RoundNotActive)?;
+
+    if round_info.is_complete {
+        return Err(ContractError::RoundNotActive);
+    }
+    if recipient != round_info.recipient {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let required_amount = group.contribution_amount
+        * group.members.len() as i128
+        * group.early_payout_threshold_bps as i128
+        / 10_000;
+    if round_info.total_contributed < required_amount {
+        return Err(ContractError::RoundNotComplete);
+    }
+
+    let token_client = soroban_sdk::token::Client::new(env, &group.token);
+    token_client.transfer(
+        &env.current_contract_address(),
+        &recipient,
+        &round_info.total_contributed,
+    );
+
+    env.events().publish(
+        (crate::symbol_short!("earlypay"),),
+        (group_id, recipient, round_info.total_contributed),
+    );
+
+    advance_round(env, group_id, &mut group)
+}
+
+pub fn set_early_payout_threshold(
+    env: &Env,
+    admin: Address,
+    group_id: u64,
+    threshold_bps: u32,
+) -> Result<(), ContractError> {
+    admin.require_auth();
+
+    let mut group = storage::get_group(env, group_id).ok_or(ContractError::GroupNotFound)?;
+    if admin != group.admin {
+        return Err(ContractError::Unauthorized);
+    }
+    if threshold_bps == 0 || threshold_bps > 10_000 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    group.early_payout_threshold_bps = threshold_bps;
+    storage::set_group(env, &group);
+
+    env.events().publish(
+        (crate::symbol_short!("earlythr"),),
+        (group_id, threshold_bps),
+    );
+
+    Ok(())
+}
+
+fn advance_round(
+    env: &Env,
+    group_id: u64,
+    group: &mut crate::types::SavingsGroup,
+) -> Result<(), ContractError> {
     // Advance to next round or complete the group
     if group.current_round >= group.total_rounds {
         group.status = GroupStatus::Completed;
-        storage::set_group(env, &group);
+        storage::set_group(env, group);
 
         env.events()
             .publish((crate::symbol_short!("grp_comp"),), group_id);
@@ -56,7 +137,7 @@ pub fn distribute_payout(env: &Env, group_id: u64) -> Result<(), ContractError> 
         };
 
         storage::set_round(env, group_id, &new_round);
-        storage::set_group(env, &group);
+        storage::set_group(env, group);
 
         env.events().publish(
             (crate::symbol_short!("rnd_new"),),

--- a/contracts/sorosave/src/test.rs
+++ b/contracts/sorosave/src/test.rs
@@ -48,6 +48,7 @@ fn test_create_group() {
     assert_eq!(group.admin, admin);
     assert_eq!(group.contribution_amount, 1_000_000);
     assert_eq!(group.max_members, 5);
+    assert_eq!(group.early_payout_threshold_bps, 10_000);
     assert_eq!(group.status, GroupStatus::Forming);
     assert_eq!(group.members.len(), 1);
 }
@@ -221,4 +222,46 @@ fn test_set_group_admin() {
 
     let group = client.get_group(&group_id);
     assert_eq!(group.admin, new_admin);
+}
+
+#[test]
+fn test_request_early_payout_advances_round() {
+    let (env, admin, client, _token) = setup_env();
+    let mint_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(mint_admin.clone());
+    let token = token_id.address();
+    let token_sac = StellarAssetClient::new(&env, &token);
+
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    token_sac.mint(&admin, &10_000_000);
+    token_sac.mint(&member1, &10_000_000);
+    token_sac.mint(&member2, &10_000_000);
+
+    let group_id = client.create_group(
+        &admin,
+        &String::from_str(&env, "Early Payout Test"),
+        &token,
+        &1_000_000,
+        &86400,
+        &5,
+    );
+    client.join_group(&member1, &group_id);
+    client.join_group(&member2, &group_id);
+    client.set_early_payout_threshold(&admin, &group_id, &5_000);
+    client.start_group(&admin, &group_id);
+
+    client.contribute(&admin, &group_id);
+
+    let too_early = client.try_request_early_payout(&admin, &group_id);
+    assert!(too_early.is_err());
+
+    client.contribute(&member1, &group_id);
+
+    let admin_balance_before = soroban_sdk::token::Client::new(&env, &token).balance(&admin);
+    client.request_early_payout(&admin, &group_id);
+    let admin_balance_after = soroban_sdk::token::Client::new(&env, &token).balance(&admin);
+
+    assert_eq!(admin_balance_after - admin_balance_before, 2_000_000);
+    assert_eq!(client.get_group(&group_id).current_round, 2);
 }

--- a/contracts/sorosave/src/types.rs
+++ b/contracts/sorosave/src/types.rs
@@ -22,6 +22,7 @@ pub struct SavingsGroup {
     pub contribution_amount: i128,
     pub cycle_length: u64,
     pub max_members: u32,
+    pub early_payout_threshold_bps: u32,
     pub members: Vec<Address>,
     pub payout_order: Vec<Address>,
     pub current_round: u32,


### PR DESCRIPTION
## Summary

Implements early payout requests for #8.

- Adds `early_payout_threshold_bps` to group state.
- Adds admin `set_early_payout_threshold` configuration.
- Adds recipient-only `request_early_payout`.
- Transfers the currently contributed partial pot when the threshold is met.
- Advances the group to the next round after early payout.
- Adds a test covering threshold rejection, successful partial payout, and round advancement.

## Verification

- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Closes #8